### PR TITLE
Merge API variables and CLI variables in tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,14 @@
 				{
 					"type": "webview",
 					"id": "devcycle-sidebar",
-					"name": "DevCycle"
+					"name": "DevCycle",
+					"when": "devcycle-featureflags.hasCredentialsAndProject == false"
+				}, 
+				{
+					"type": "tree",
+					"id": "devcycleCodeUsages",
+					"name": "DevCycle Variables",
+					"when": "devcycle-featureflags.hasCredentialsAndProject == true"
 				}
 			]
 		},
@@ -68,7 +75,7 @@
 					"light": "media/togglebot.svg",
 					"dark": "media/togglebot-white.svg"
 				},
-				"enablement": "devcycle-featureflags.loggedIn == true"
+				"enablement": "devcycle-featureflags.loggedIn == true || devcycle-featureflags.hasCredentialsAndProject == true"
 			},
 			{
 				"command": "devcycle-featureflags.refresh-usages",

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -17,7 +17,9 @@ export class StateManager {
 
   static clearState(){
     this.workspaceState.keys().forEach((key) => {
-      this.workspaceState.update(key, undefined)
+      if (key !== KEYS.PROJECT_ID && key !== KEYS.PROJECT_NAME) {
+        this.workspaceState.update(key, undefined)
+      }
     })
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,17 @@
+import { getAllEnvironments } from "./environmentsCLIController";
+import { getAllFeatures } from "./featuresCLIController";
+import { getAllVariables } from "./variablesCLIController";
+
 export * from "./baseCLIController";
 export * from "./featuresCLIController";
 export * from "./variablesCLIController";
 export * from "./environmentsCLIController";
+
+
+export const initStorage = async () => {
+    await Promise.all([
+        getAllVariables(),
+        getAllFeatures(),
+        getAllEnvironments(),
+    ]);
+}

--- a/src/cli/variablesCLIController.ts
+++ b/src/cli/variablesCLIController.ts
@@ -5,6 +5,7 @@ import { execDvc } from "./baseCLIController";
 export type Variable = {
   key: string;
   _feature: string;
+  _id: string;
   name: string;
   description?: string;
   status: "active" | "archived";


### PR DESCRIPTION

Updates:
- added the list of all variables from the API to UsagesTreeProvider, and updated it to show two optional sections: Details and Usages. If we don't have a variable from the API for a given code usage, its details will be omitted. Variables that don't have any usages in this workspace will only have details with no usages
- Because we need to support 2 kinds of views, i added a new workspace context `hasCredentialsAndProject`
 so vscode can toggle between SidebarProvider view and UsagesTreeProvider view. In order to be able to go back and forth between the views smoothly I set hasCredentialsAndProject when:
    - the user submits the project form (meaning they just entered their credentials in the last form)
    - on load if we have client id, secret, and project (and the user hasn't turned off autoLogin)
    - and to make testing easier, i added the logic to clear `hasCredentialsAndProject` when you run the log out command 

https://github.com/DevCycleHQ-Internal/DVC-extension/assets/25067948/9e4a6298-f5b9-4683-8353-98c0c756323b
