### PR TITLE
FIX: infinite loading spinner on startup

### DIFF
--- a/src/cli/baseCLIController.ts
+++ b/src/cli/baseCLIController.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as cp from 'child_process'
 import { getCredentials } from '../utils/credentials'
 import { StateManager, KEYS } from '../StateManager'
-
+import { showBusyMessage, hideBusyMessage } from '../components/statusBarItem'
 type CommandResponse = {
   output: string
   error: Error | null
@@ -46,11 +46,9 @@ export type Range = {
   end: number
 }
 
-const STATUS_BAR_ITEM: string = 'devcycle-featureflags'
 const CACHE_TIME = 15000
 
-export const statusBarItem = vscode.window.createStatusBarItem(STATUS_BAR_ITEM)
-statusBarItem.name = 'DevCycle Status'
+
 
 export async function init() {
   showBusyMessage('Initializing DevCycle')
@@ -64,7 +62,7 @@ export async function init() {
   } else {
     vscode.window.showErrorMessage(`Login failed ${error?.message}}`)
   }
-  hideStatus()
+  hideBusyMessage()
   const organizations = JSON.parse(output) as string[]
   await chooseOrganization(organizations)
   await vscode.commands.executeCommand('devcycle-featureflags.refresh-usages')
@@ -84,7 +82,7 @@ export async function login() {
   } else {
     vscode.window.showErrorMessage(`Login failed ${error?.message}}`)
   }
-  hideStatus()
+  hideBusyMessage()
 }
 
 export async function chooseOrganization(organizations: string[]) {
@@ -99,7 +97,7 @@ export async function chooseOrganization(organizations: string[]) {
       `Organization login failed ${error?.message}}`,
     )
   }
-  hideStatus()
+  hideBusyMessage()
   const projects = JSON.parse(output) as string[]
   return chooseProject(projects)
 }
@@ -130,7 +128,7 @@ export async function usages(): Promise<JSONMatch[]> {
   showBusyMessage('Finding Devcycle code usages')
   const { output } = await execDvc('usages --format=json')
   const matches = JSON.parse(output) as JSONMatch[]
-  hideStatus()
+  hideBusyMessage()
   return matches
 }
 
@@ -155,16 +153,6 @@ export async function addAlias(alias: string, variableKey: string) {
   if (code !== 0) {
     vscode.window.showErrorMessage(`Adding alias failed: ${error?.message}}`)
   }
-}
-
-function showBusyMessage(message: string) {
-  statusBarItem.text = `$(loading~spin) ${message}...`
-  statusBarItem.tooltip = `${message}...`
-  statusBarItem.show()
-}
-
-function hideStatus() {
-  statusBarItem.hide()
 }
 
 export async function execDvc(cmd: string) {

--- a/src/components/SidebarProvider.ts
+++ b/src/components/SidebarProvider.ts
@@ -1,11 +1,9 @@
 import * as vscode from 'vscode'
-import { getProject } from './api/getProject'
-import { StateManager, KEYS } from './StateManager'
-import { SecretStateManager, CLIENT_KEYS } from './SecretStateManager'
-import { getToken } from './api/getToken'
-import { getNonce } from './utils/getNonce'
-import { initStorage } from './cli'
-import { setClientIdAndSecret } from './utils/credentials'
+import { getProject } from '../api/getProject'
+import { StateManager, KEYS } from '../StateManager'
+import { getToken } from '../api/getToken'
+import { getNonce } from '../utils/getNonce'
+import { setClientIdAndSecret } from '../utils/credentials'
 
 const enum VIEWS {
   DEFAULT = 'default',
@@ -86,7 +84,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
               'devcycle-featureflags.hasCredentialsAndProject',
               true,
             )
-            await initStorage()
             await vscode.commands.executeCommand('devcycle-featureflags.refresh-usages')
           } else if (res === 404) {
             webviewView.webview.html = this._getHtmlForWebview(

--- a/src/components/UsagesTreeProvider.ts
+++ b/src/components/UsagesTreeProvider.ts
@@ -6,7 +6,10 @@ import {
   getAllVariables,
   getCombinedVariableDetails,
   CombinedVariableData,
-} from './cli'
+} from '../cli'
+
+import { showBusyMessage, hideBusyMessage } from './statusBarItem'
+
 
 type VariableCodeReference =
   | (CombinedVariableData & {
@@ -38,6 +41,7 @@ export class UsagesTreeProvider
   ) {}
 
   private async getCombinedAPIData() {
+    showBusyMessage('Fetching devcycle data')
     const variables = await getAllVariables()
     const result = {} as Record<string, VariableCodeReference>
     await Promise.all(
@@ -46,6 +50,7 @@ export class UsagesTreeProvider
         result[key] = data
       }),
     )
+    hideBusyMessage()
     return result
   }
 

--- a/src/components/hoverCard.ts
+++ b/src/components/hoverCard.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import { CombinedVariableData, getCombinedVariableDetails } from './cli'
+import { CombinedVariableData, getCombinedVariableDetails } from '../cli'
 
 export const getHoverString = async (
   variableKey: string,

--- a/src/components/statusBarItem.ts
+++ b/src/components/statusBarItem.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode'
+
+const STATUS_BAR_ITEM: string = 'devcycle-featureflags'
+export const statusBarItem = vscode.window.createStatusBarItem(STATUS_BAR_ITEM)
+statusBarItem.name = 'DevCycle Status'
+
+export function showBusyMessage(message: string) {
+    statusBarItem.text = `$(loading~spin) ${message}...`
+    statusBarItem.tooltip = `${message}...`
+    statusBarItem.show()
+  }
+  
+export function hideBusyMessage() {
+    statusBarItem.hide()
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,10 +4,10 @@ import { KEYS, StateManager } from './StateManager'
 import { init, login, logout, status as cliStatus, initStorage } from './cli'
 import { CLIENT_KEYS, SecretStateManager } from './SecretStateManager'
 import { loadConfig, autoLoginIfHaveCredentials } from './utils/credentials'
-import { SidebarProvider } from './SidebarProvider'
+import { SidebarProvider } from './components/SidebarProvider'
 
-import { UsagesTreeProvider } from './UsagesTreeProvider'
-import { getHoverString } from './hoverCard'
+import { UsagesTreeProvider } from './components/UsagesTreeProvider'
+import { getHoverString } from './components/hoverCard'
 
 Object.defineProperty(exports, '__esModule', { value: true })
 exports.deactivate = exports.activate = void 0
@@ -25,14 +25,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
   const autoLogin = vscode.workspace
     .getConfiguration('devcycle-featureflags')
     .get('loginOnWorkspaceOpen')
-
-  if (autoLogin) {
-    const isLoggedIn = await autoLoginIfHaveCredentials()
-    if (isLoggedIn) {
-      await initStorage()
-      await vscode.commands.executeCommand('devcycle-featureflags.refresh-usages')
-    }
-  }
 
   const sidebarProvider = new SidebarProvider(context.extensionUri)
 
@@ -113,6 +105,13 @@ export const activate = async (context: vscode.ExtensionContext) => {
       },
     ),
   )
+
+  if (autoLogin) {
+    const isLoggedIn = await autoLoginIfHaveCredentials()
+    if (isLoggedIn) {
+      await vscode.commands.executeCommand('devcycle-featureflags.refresh-usages')
+    }
+  }
 
   const status = await cliStatus()
   if (status.organization) {


### PR DESCRIPTION
- THE FIX: Moved the auto-login flow below the command definitions so we can use the refresh-usages command safely
- Create components directory and move files that pertain to visual components within
- Refactor sidebarstatus into component so it can be used outside of cli controller
- Removed `initStorage` from the activate function since the state gets immediately cleared when the `refresh-usages` command is called (and data is then refetched) 