### PR TITLE
Include org id and project in variable dashboard links

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -7,6 +7,7 @@ export const enum KEYS {
   VARIABLES = 'variables',
   FEATURE_CONFIGURATIONS = 'feature_configurations',
   ENVIRONMENTS = 'environments',
+  ORGANIZATION_ID = 'organization_id',
 }
 
 export class StateManager {

--- a/src/cli/cliUtils.ts
+++ b/src/cli/cliUtils.ts
@@ -1,3 +1,6 @@
+import { KEYS, StateManager } from '../StateManager'
+import { getToken } from '../api/getToken'
+import { getCredentials } from '../utils/credentials'
 import { getAllEnvironments, getEnvironment } from './environmentsCLIController'
 import {
   Feature,
@@ -68,4 +71,20 @@ export const getCombinedVariableDetails = async (
     feature,
     configurations: featureConfigsWithEnvNames,
   }
+}
+
+export const getOrganizationId = async () => {
+  const cachedOrganizationId = StateManager.getState(KEYS.ORGANIZATION_ID)
+  if (cachedOrganizationId) {
+    return cachedOrganizationId
+  }
+  const { client_id, client_secret } = await getCredentials()
+  if (!client_id || !client_secret) {
+    return 
+  }
+  const token = await getToken(client_id, client_secret)
+  const jsonToken = JSON.parse(Buffer.from(token.access_token.split('.')[1], 'base64').toString())
+  const orgId =  jsonToken['https://devcycle.com/org_id']
+  StateManager.setState(KEYS.ORGANIZATION_ID, orgId)
+  return orgId
 }


### PR DESCRIPTION
<img width="603" alt="image" src="https://github.com/DevCycleHQ-Internal/DVC-extension/assets/25067948/97bbe5cf-f3bf-4c9f-aa5c-5c0ff7db01ba">

- get org Id from token (and store in StateManager to avoid having to fetch token again)
- use org Id and project Id in the variable URL so that the variable can be found even if you have a different org active in the browser 