### PR TITLE
pre-seed all variables/features/envs before refreshing

### DIFF
--- a/src/components/UsagesTreeProvider.ts
+++ b/src/components/UsagesTreeProvider.ts
@@ -4,9 +4,11 @@ import {
   JSONMatch,
   VariableReference,
   getAllVariables,
+  getAllEnvironments,
   getCombinedVariableDetails,
   CombinedVariableData,
   getOrganizationId,
+  getAllFeatures,
 } from '../cli'
 
 import { showBusyMessage, hideBusyMessage } from './statusBarItem'
@@ -44,7 +46,7 @@ export class UsagesTreeProvider
 
   private async getCombinedAPIData() {
     showBusyMessage('Fetching devcycle data')
-    const variables = await getAllVariables()
+    const [variables] = await Promise.all([getAllVariables(), getAllFeatures(), getAllEnvironments()])
     const result = {} as Record<string, VariableCodeReference>
     await Promise.all(
       Object.entries(variables).map(async ([key, variable]) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
   SecretStateManager.init(context)
   StateManager.globalState = context.globalState
   StateManager.workspaceState = context.workspaceState
-  StateManager.clearState()
   const autoLogin = vscode.workspace
     .getConfiguration('devcycle-featureflags')
     .get('loginOnWorkspaceOpen')


### PR DESCRIPTION
- This will prevent the need to fetch every single feature/env individually by caching all of the data in the state 