### PR TITLE
Show hover card if key is in api variables or usages

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -9,6 +9,7 @@ export const enum KEYS {
   ENVIRONMENTS = 'environments',
   ORGANIZATION_ID = 'organization_id',
   SEND_METRICS_PROMPTED = 'send_metrics_prompted',
+  CODE_USAGE_KEYS = 'code_usage_keys',
 }
 
 export class StateManager {

--- a/src/cli/baseCLIController.ts
+++ b/src/cli/baseCLIController.ts
@@ -144,6 +144,7 @@ export async function usages(): Promise<JSONMatch[]> {
   
   const matches = JSON.parse(output) as JSONMatch[]
   hideBusyMessage()
+  StateManager.setState(KEYS.CODE_USAGE_KEYS, matches.map((match) => match.key))
   return matches
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,9 +151,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
       const variableKey = document.getText(range)
       const variables =
         (StateManager.getState(KEYS.VARIABLES) as Record<string, Variable>) || {}
-      const variable = variables[variableKey]
+      const keyInAPIVariables = !!variables[variableKey]        
+      const keyInCodeUsages = (StateManager.getState(KEYS.CODE_USAGE_KEYS) as string[])?.includes(variableKey)
       
-      if (!variable) {
+      if (!keyInAPIVariables && !keyInCodeUsages) {
         return
       }
 


### PR DESCRIPTION
keeps a copy of our last code usages in StateManager so we can check if the hovered text exists in either the api variables or the known code usages when deciding whether to show the hover card 