### PR TITLE
refactor: Overload StateManager methods to avoid type casting

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { Environment, Feature, FeatureConfiguration, Organization, Variable } from './cli'
 
 export const enum KEYS {
   PROJECT_ID = 'project_id',
@@ -24,10 +25,26 @@ export class StateManager {
     })
   }
 
+  static setState(key: KEYS.PROJECT_ID | KEYS.PROJECT_NAME, value: string | undefined): Thenable<void>
+  static setState(key: KEYS.FEATURES, value: Record<string, Feature> | undefined): Thenable<void>
+  static setState(key: KEYS.VARIABLES, value: Record<string, Variable> | undefined): Thenable<void>
+  static setState(key: KEYS.FEATURE_CONFIGURATIONS, value: Record<string, FeatureConfiguration[]> | undefined): Thenable<void>
+  static setState(key: KEYS.ENVIRONMENTS, value: Record<string, Environment> | undefined): Thenable<void>
+  static setState(key: KEYS.ORGANIZATION, value: Organization | undefined): Thenable<void>
+  static setState(key: KEYS.SEND_METRICS_PROMPTED, value: boolean | undefined): Thenable<void>
+  static setState(key: KEYS.CODE_USAGE_KEYS, value: string[] | undefined): Thenable<void>
   static setState(key: string, value: any) {
     return this.workspaceState.update(key, value)
   }
 
+  static getState(key: KEYS.PROJECT_ID | KEYS.PROJECT_NAME): string | undefined
+  static getState(key: KEYS.FEATURES): Record<string, Feature> | undefined
+  static getState(key: KEYS.VARIABLES): Record<string, Variable> | undefined
+  static getState(key: KEYS.FEATURE_CONFIGURATIONS): Record<string, FeatureConfiguration[]> | undefined
+  static getState(key: KEYS.ENVIRONMENTS): Record<string, Environment> | undefined
+  static getState(key: KEYS.ORGANIZATION): Organization | undefined
+  static getState(key: KEYS.SEND_METRICS_PROMPTED): boolean | undefined
+  static getState(key: KEYS.CODE_USAGE_KEYS): string[] | undefined
   static getState(key: string) {
     return this.workspaceState.get(key)
   }

--- a/src/cli/cliUtils.ts
+++ b/src/cli/cliUtils.ts
@@ -73,6 +73,6 @@ export const getCombinedVariableDetails = async (
 }
 
 export const getOrganizationId = async () => {
-  const cachedOrganization = StateManager.getState(KEYS.ORGANIZATION) as Organization
-  return cachedOrganization.id
+  const cachedOrganization = StateManager.getState(KEYS.ORGANIZATION)
+  return cachedOrganization?.id
 }

--- a/src/cli/environmentsCLIController.ts
+++ b/src/cli/environmentsCLIController.ts
@@ -8,8 +8,7 @@ export type Environment = {
 }
 
 export async function getEnvironment(environmentId: string) {
-  const environments = (StateManager.getState(KEYS.ENVIRONMENTS) ||
-    {}) as Record<string, Environment>
+  const environments = StateManager.getState(KEYS.ENVIRONMENTS) || {}
   const environment = environments[environmentId]
   if (environment) {
     return environment
@@ -38,10 +37,7 @@ export async function getEnvironment(environmentId: string) {
 }
 
 export async function getAllEnvironments() {
-  const environments = StateManager.getState(KEYS.ENVIRONMENTS) as Record<
-    string,
-    Environment
-  >
+  const environments = StateManager.getState(KEYS.ENVIRONMENTS)
   if (environments) {
     return environments
   }

--- a/src/cli/featuresCLIController.ts
+++ b/src/cli/featuresCLIController.ts
@@ -15,14 +15,8 @@ export type FeatureConfiguration = {
   _environment: string
 }
 
-export type FeatureConfigurationsByFeatureId = Record<
-  string,
-  FeatureConfiguration[]
->
-
 export async function getFeature(featureId: string) {
-  const features =
-    (StateManager.getState(KEYS.FEATURES) as Record<string, Feature>) || {}
+  const features = StateManager.getState(KEYS.FEATURES) || {}
   const feature = features[featureId]
   if (feature) {
     return feature
@@ -49,10 +43,7 @@ export async function getFeature(featureId: string) {
 }
 
 export async function getAllFeatures() {
-  const features = StateManager.getState(KEYS.FEATURES) as Record<
-    string,
-    Feature
-  >
+  const features = StateManager.getState(KEYS.FEATURES)
   if (features) {
     return features
   }
@@ -75,10 +66,7 @@ export async function getAllFeatures() {
 }
 
 export async function getFeatureConfigurations(featureId: string) {
-  const featureConfigsMap =
-    (StateManager.getState(
-      KEYS.FEATURE_CONFIGURATIONS,
-    ) as FeatureConfigurationsByFeatureId) || {}
+  const featureConfigsMap = StateManager.getState( KEYS.FEATURE_CONFIGURATIONS) || {}
   const featureConfigs = featureConfigsMap[featureId]
   if (featureConfigs) {
     return featureConfigs

--- a/src/cli/variablesCLIController.ts
+++ b/src/cli/variablesCLIController.ts
@@ -12,8 +12,7 @@ export type Variable = {
 }
 
 export async function getVariable(variableKey: string) {
-  const variables =
-    (StateManager.getState(KEYS.VARIABLES) as Record<string, Variable>) || {}
+  const variables = StateManager.getState(KEYS.VARIABLES) || {}
   const variable = variables[variableKey]
   if (variable) {
     return variable

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,10 +146,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
       }
 
       const variableKey = document.getText(range)
-      const variables =
-        (StateManager.getState(KEYS.VARIABLES) as Record<string, Variable>) || {}
+      const variables = StateManager.getState(KEYS.VARIABLES) || {}
       const keyInAPIVariables = !!variables[variableKey]        
-      const keyInCodeUsages = (StateManager.getState(KEYS.CODE_USAGE_KEYS) as string[])?.includes(variableKey)
+      const keyInCodeUsages = StateManager.getState(KEYS.CODE_USAGE_KEYS)?.includes(variableKey)
       
       if (!keyInAPIVariables && !keyInCodeUsages) {
         return


### PR DESCRIPTION
Overload StateManager methods with corresponding types for each key so that we don't need to cast the type when reading from state