### PR TITLE
dont fetch feature configurations on startup

### DIFF
--- a/src/cli/cliUtils.ts
+++ b/src/cli/cliUtils.ts
@@ -30,6 +30,7 @@ export const initStorage = async () => {
 
 export const getCombinedVariableDetails = async (
   variable: string | Variable,
+  skipConfigurations: boolean = false
 ) => {
   let fullVariable: Variable
   if (typeof variable === 'string') {
@@ -49,6 +50,7 @@ export const getCombinedVariableDetails = async (
     }
 
     const setFeatureConfigsWithEnvNames = async () => {
+      if (skipConfigurations) return
       const featureConfigurations = await getFeatureConfigurations(featureId)
       await Promise.all(
         featureConfigurations?.map(async (config) => {

--- a/src/components/UsagesTree/UsagesTreeProvider.ts
+++ b/src/components/UsagesTree/UsagesTreeProvider.ts
@@ -33,7 +33,7 @@ export class UsagesTreeProvider
     const result = {} as Record<string, VariableCodeReference>
     await Promise.all(
       Object.entries(variables).map(async ([key, variable]) => {
-        const data = await getCombinedVariableDetails(variable)
+        const data = await getCombinedVariableDetails(variable, true)
         result[key] = data
       }),
     )


### PR DESCRIPTION
- Add skipConfigurations parameter to the `getCombinedVariableDetails` function that allows us to skip fetching each feature configuration individually