### PR TITLE
chore: fix gh action step by pushing commit and checking prerelease input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,12 @@ jobs:
 
       - name: Publish VSCode Extension
         run: |
-          yarn run publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} ${{ github.event.inputs.prerelease && '--pre-release' }}
+          yarn run publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} ${{ github.event.inputs.prerelease === 'true' && '--pre-release' }}
+
+      - name: Push version change
+        run: |
+          git push origin HEAD:main
+        if: inputs.draft != true
 
       - uses: DevCycleHQ/release-action/create-release@main
         id: create-release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "devcycle-feature-flags",
   "displayName": "DevCycle Feature Flags",
   "description": "DevCycle is an intuitive extension for Visual Studio Code, built to manage and keep track of your feature flags from the comfort of your IDE.",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publisher": "DevCycle",
   "icon": "media/togglebot.png",
   "engines": {


### PR DESCRIPTION
# Changes

- check input properly to prevent adding pre-release tag always
- push commit changes so that version bumps are committed