### PR TITLE
Add wrapper to get repo config

### DIFF
--- a/src/cli/organizationsCLIController.ts
+++ b/src/cli/organizationsCLIController.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode'
 import { execDvc } from './baseCLIController'
 import { getAllProjects, selectProjectFromConfig, selectProjectFromList } from './projectsCLIController'
 import { KEYS, StateManager } from '../StateManager'
-import { loadRepoConfig } from '../utils'
 import { hideBusyMessage, showBusyMessage } from '../components/statusBarItem'
+import { getRepoConfig } from '../utils'
 
 export type Organization = {
   id: string
@@ -12,7 +12,7 @@ export type Organization = {
 }
 
 export async function selectOrganizationFromConfig() {
-  const { org: orgFromConfig } = StateManager.getState(KEYS.REPO_CONFIG) || {}
+  const { org: orgFromConfig } = await getRepoConfig()
 
   if (orgFromConfig) {
     await execDvc('login again')

--- a/src/cli/projectsCLIController.ts
+++ b/src/cli/projectsCLIController.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { KEYS, StateManager } from '../StateManager'
 import { execDvc } from './baseCLIController'
-import { loadRepoConfig } from '../utils'
+import { getRepoConfig } from '../utils'
 
 export type Project = {
   _id: string
@@ -33,7 +33,7 @@ export async function getAllProjects() {
 }
 
 export async function selectProjectFromConfig() {
-  const { project: projFromConfig } = StateManager.getState(KEYS.REPO_CONFIG) || {}
+  const { project: projFromConfig } = await getRepoConfig()
 
   if (projFromConfig) {
     await selectProject(projFromConfig)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { UsagesTreeProvider } from './components/UsagesTree'
 import { getHoverString } from './components/hoverCard'
 import { trackRudderstackEvent } from './RudderStackService'
 import { CodeUsageNode } from './components/UsagesTree/CodeUsageNode'
-import { loadRepoConfig } from './utils'
+import { getRepoConfig, loadRepoConfig } from './utils'
 
 Object.defineProperty(exports, '__esModule', { value: true })
 exports.deactivate = exports.activate = void 0
@@ -182,7 +182,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         return
       }
 
-      const variableAliases = StateManager.getState(KEYS.REPO_CONFIG)?.codeInsights?.variableAliases || {}
+      const variableAliases = (await getRepoConfig()).codeInsights?.variableAliases || {}
       let variableKey = document.getText(range)
       variableKey = variableAliases[variableKey] || variableKey
 

--- a/src/utils/loadRepoConfig.ts
+++ b/src/utils/loadRepoConfig.ts
@@ -26,9 +26,19 @@ export const loadRepoConfig = async (): Promise<RepoConfig> => {
       const configFileString = new TextDecoder().decode(configFileByteArray)
       const configFileJson = yaml.load(configFileString) as RepoConfig
       StateManager.setState(KEYS.REPO_CONFIG, configFileJson)
-      return configFileJson
+      return configFileJson || {}
     } catch (e) {}
   }
   StateManager.setState(KEYS.REPO_CONFIG, {})
   return {}
+}
+
+export const getRepoConfig = async () => {
+  const storedConfig = StateManager.getState(KEYS.REPO_CONFIG)
+  if (storedConfig) {
+    return storedConfig
+  }
+  else {
+    return await loadRepoConfig()
+  }
 }


### PR DESCRIPTION
Currently when we call StateManager.clearState in the refresh code usages command, it wipes out the repo config which breaks the alias matching. this way we'll reload the config before using it if it's not currently in state