### PR TITLE
feat: add sidebar views for install cli and open folder

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -4,6 +4,8 @@
   --input-padding-horizontal: 4px;
   --input-margin-vertical: 4px;
   --input-margin-horizontal: 0;
+  --preview-padding-vertical: 10px;
+  --preview-padding-horizontal: 20px;
 }
 
 body {
@@ -42,6 +44,15 @@ a:active {
 code {
   font-size: var(--vscode-editor-font-size);
   font-family: var(--vscode-editor-font-family);
+}
+
+pre {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--preview-padding-vertical) var(--preview-padding-horizontal);
+  background-color: var(--vscode-input-background);
+  overflow-x: auto;
 }
 
 button {

--- a/package.json
+++ b/package.json
@@ -38,9 +38,15 @@
       "dvcView": [
         {
           "type": "webview",
+          "id": "devcycle-startup",
+          "name": "DevCycle",
+          "when": "devcycle-feature-flags.shouldShowCliView || devcycle-feature-flags.shouldShowWorkspaceView"
+        },
+        {
+          "type": "webview",
           "id": "devcycle-sidebar",
-          "name": "Login",
-          "when": "devcycle-feature-flags.hasCredentialsAndProject == false"
+          "name": "DevCycle",
+          "when": "!devcycle-feature-flags.shouldShowCliView && !devcycle-feature-flags.shouldShowWorkspaceView && !devcycle-feature-flags.hasCredentialsAndProject"
         },
         {
           "type": "tree",

--- a/src/cli/baseCLIController.ts
+++ b/src/cli/baseCLIController.ts
@@ -154,14 +154,8 @@ function execShell(cmd: string) {
   showDebugOutput(`Executing shell command ${cmd}`)
   return new Promise<CommandResponse>((resolve, reject) => {
     const workspace = getWorkspace()
-    if (!workspace) {
-      vscode.window.showErrorMessage(
-        'DevCycle extension requires an open workspace',
-      )
-      return
-    }
     const cpOptions: cp.ExecOptions = {
-      cwd: workspace.uri.fsPath,
+      cwd: workspace?.uri?.fsPath,
     }
     cp.exec(cmd, cpOptions, (err, out) => {
       if (err) {
@@ -199,4 +193,14 @@ function showDebugOutput(message: string) {
   if (debug) {
     vscode.window.showInformationMessage(message)
   }
+}
+
+export async function isCliInstalled() {
+  const { error } = await execDvc('--version')
+  return !error
+}
+
+export function hasWorkSpace() {
+  const workspaces = vscode.workspace.workspaceFolders
+  return !!workspaces
 }

--- a/src/components/StartupViewProvider.ts
+++ b/src/components/StartupViewProvider.ts
@@ -1,0 +1,129 @@
+import * as vscode from 'vscode'
+import { getNonce } from '../utils/getNonce'
+import { setUpCliStartupView, setUpWorkspaceStartupView } from '../utils/setUpViews'
+
+export const enum STARTUP_VIEWS {
+  CLI = 'cli',
+  WORKSPACE = 'workspace',
+}
+
+enum BUTTON_TYPES {
+  CLI = 'installedCli',
+  WORKSPACE = 'openFolder',
+}
+
+export class StartupViewProvider implements vscode.WebviewViewProvider {
+  _view?: vscode.WebviewView
+
+  constructor(private readonly _extensionUri: vscode.Uri, private viewType: STARTUP_VIEWS) { }
+
+  public async resolveWebviewView(webviewView: vscode.WebviewView) {
+    this._view = webviewView
+
+    webviewView.webview.options = {
+      enableScripts: true,
+
+      localResourceRoots: [this._extensionUri],
+    }
+
+    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, this.viewType)
+
+    webviewView.webview.onDidReceiveMessage(async (data: { btnType: BUTTON_TYPES }) => {
+      if (data.btnType === BUTTON_TYPES.CLI) {
+        const { shouldShowCliStartUpView, shouldShowWorkspaceView } = await this.checkView()
+        if (shouldShowWorkspaceView && !shouldShowCliStartUpView) {
+          webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, STARTUP_VIEWS.WORKSPACE)
+        }
+      } else if (data.btnType === BUTTON_TYPES.WORKSPACE) {
+        await vscode.commands.executeCommand('vscode.openFolder')
+      }
+    })
+  }
+
+  public revive(panel: vscode.WebviewView) {
+    this._view = panel
+  }
+
+  private getScriptUri(webview: vscode.Webview): vscode.Uri {
+    const isDebug = process.env.DEBUG_MODE === '1'
+    const script = `startup.${isDebug ? 'ts' : 'js'}`
+    return webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, isDebug ? 'src' : 'out', `scripts/${script}`),
+    )
+  }
+
+  private getBodyHtml(
+    view: STARTUP_VIEWS,
+  ): string {
+    let body = ''
+
+    if (view === STARTUP_VIEWS.CLI) {
+      body = `<br/>
+        <p>In order to use DevCycle extension, please install Devcycle CLI.</p>
+        <br/>
+        <p>To install via npm, use the command: </p>
+        <pre><code>npm install -g @devcycle/cli</code></pre>
+        <br/>
+        <p>To install via brew, use the command: </p>
+        <pre><code>brew install devcycle-cli</code></pre>
+        <br/>
+        <button id="installedCli">I have installed DevCycle CLI</button>
+        <br/>
+        <p>To learn more about DevCycle and this extension, <a href="https://docs.devcycle.com">read our docs</a></p>
+        `
+    }
+    if (view === STARTUP_VIEWS.WORKSPACE) {
+      body = `<br/>
+        <p>In order to use DevCycle features, open a folder.</p>
+        <button id="openFolder">Open folder</button>
+        <p>To learn more about DevCycle and this extension, <a href="https://docs.devcycle.com">read our docs</a></p>
+        `
+    }
+    return body
+  }
+
+  private _getHtmlForWebview(
+    webview: vscode.Webview,
+    view: STARTUP_VIEWS,
+  ) {
+    const styleResetUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, 'media', 'reset.css'),
+    )
+
+    const styleVSCodeUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, 'media', 'vscode.css'),
+    )
+
+    const scriptUri = this.getScriptUri(webview)
+
+    const nonce = getNonce()
+
+    return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<!--
+					Use a content security policy to only allow loading images from https or from our extension directory,
+					and only allow scripts that have a specific nonce.
+        -->
+        <meta http-equiv="Content-Security-Policy" content="img-src https: data:; style-src 'unsafe-inline' ${webview.cspSource
+      }; script-src 'nonce-${nonce}';">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<link href="${styleResetUri}" rel="stylesheet">
+				<link href="${styleVSCodeUri}" rel="stylesheet">
+        
+        </head>
+        <body>
+        ${this.getBodyHtml(view)}
+        </body>
+        <script nonce="${nonce}" src="${scriptUri}"></script>
+        </html>`
+  }
+
+  private async checkView() {
+    return {
+      shouldShowCliStartUpView: await setUpCliStartupView(),
+      shouldShowWorkspaceView: setUpWorkspaceStartupView()
+    }
+  }
+}

--- a/src/scripts/startup.ts
+++ b/src/scripts/startup.ts
@@ -1,0 +1,18 @@
+; (function () {
+    const vscode = acquireVsCodeApi()
+    const cliBtn = document.querySelector('#installedCli')
+    const openFolderBtn = document.querySelector('#openFolder')
+
+    cliBtn?.addEventListener('click', () => {
+        vscode.postMessage({
+            btnType: 'installedCli'
+        })
+    })
+
+    openFolderBtn?.addEventListener('click', () => {
+        vscode.postMessage({
+            btnType: 'openFolder'
+        })
+    })
+
+})()

--- a/src/utils/setUpViews.ts
+++ b/src/utils/setUpViews.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode'
+import { hasWorkSpace, isCliInstalled } from '../cli'
+
+export const setUpCliStartupView = async () => {
+    const shouldShowCliStartUpView = !(await isCliInstalled())
+
+    vscode.commands.executeCommand(
+        'setContext',
+        'devcycle-feature-flags.shouldShowCliView',
+        shouldShowCliStartUpView,
+    )
+
+    if (shouldShowCliStartUpView) {
+        vscode.window.showErrorMessage(
+            'In order to use DevCycle extension, please install Devcycle CLI.'
+        )
+    }
+
+    return shouldShowCliStartUpView
+}
+
+export const setUpWorkspaceStartupView = () => {
+    const shouldShowWorkspaceView = !hasWorkSpace()
+
+    vscode.commands.executeCommand(
+        'setContext',
+        'devcycle-feature-flags.shouldShowWorkspaceView',
+        shouldShowWorkspaceView,
+    )
+
+    return shouldShowWorkspaceView
+}


### PR DESCRIPTION
- add startup views
  - install cli view with code snippet and installed button(added this button to get the next view)
  - open workspace view
- add error message popup
- removed open workspace error message popup
![cli](https://github.com/DevCycleHQ/vscode-extension/assets/69351113/5e1b61b2-5e75-44aa-867f-1c5573fa1f39)
![workspace](https://github.com/DevCycleHQ/vscode-extension/assets/69351113/c2c4b45a-88be-4d14-95c8-9315bbe921a3)
