### PR TITLE
feat: Split code usages by folder if multiple are open

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         },
         {
           "type": "tree",
-          "id": "devcycleCodeUsages",
+          "id": "devcycle-code-usages",
           "name": "Variables",
           "when": "devcycle-feature-flags.hasCredentialsAndProject == true"
         }
@@ -61,7 +61,7 @@
       "view/title": [
         {
           "command": "devcycle-feature-flags.refresh-usages",
-          "when": "view == devcycleCodeUsages",
+          "when": "view == devcycle-code-usages",
           "group": "navigation"
         }
       ]

--- a/src/components/SidebarProvider.ts
+++ b/src/components/SidebarProvider.ts
@@ -36,17 +36,19 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     webviewView.webview.onDidReceiveMessage(async (data: Data) => {
       if (data.type === ACTIONS.LOGIN) {
         try {
-          vscode.workspace.workspaceFolders?.forEach(async (folder) => {
+          const folders = vscode.workspace.workspaceFolders || []
+
+          for (const folder of folders) {
             const cli = new AuthCLIController(folder)
             await cli.login()
+          }
+          await vscode.commands.executeCommand('devcycle-feature-flags.refresh-usages')
 
-            await vscode.commands.executeCommand(
-              'setContext',
-              'devcycle-feature-flags.hasCredentialsAndProject',
-              true,
-            )
-            await vscode.commands.executeCommand('devcycle-feature-flags.refresh-usages', folder)
-          })
+          await vscode.commands.executeCommand(
+            'setContext',
+            'devcycle-feature-flags.hasCredentialsAndProject',
+            true,
+          )
         } catch (e) {
           webviewView.webview.html = this._getHtmlForWebview(
             webviewView.webview,

--- a/src/components/UsagesTree/FolderNode.ts
+++ b/src/components/UsagesTree/FolderNode.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode'
+
+export class FolderNode extends vscode.TreeItem {
+  constructor(
+    public folder: vscode.WorkspaceFolder,
+  ) {
+    super(folder.name, vscode.TreeItemCollapsibleState.Expanded)
+  }
+}


### PR DESCRIPTION
If the current workspace contains multiple folders, split the code usages sidebar by folder. If only one folder exists, do not show a dropdown. Previously only the first folder would be displayed

![Screen Shot 2023-08-10 at 11 54 15 AM](https://github.com/DevCycleHQ/vscode-extension/assets/22960213/a7563f4d-9eb3-4fc7-a3d0-dec0dc2f98fe)
