### PR TITLE
chore: udpate cli installed and workspace button logic

### DIFF
--- a/src/scripts/startup.ts
+++ b/src/scripts/startup.ts
@@ -1,4 +1,4 @@
-; (function () {
+;(function () {
     const vscode = acquireVsCodeApi()
     const cliBtn = document.querySelector('#installedCli')
     const openFolderBtn = document.querySelector('#openFolder')


### PR DESCRIPTION
- update workspace button to show cli start up view after clicking it
- update installed cli button to refresh usages after clicking it
- remove `webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, STARTUP_VIEWS.WORKSPACE)` on cli installed button clicked as we change the view order of "open workspace" and "install cli"