### PR TITLE
fix: Add folder name to org/project prompt

### DIFF
--- a/src/cli/OrganizationsCLIController.ts
+++ b/src/cli/OrganizationsCLIController.ts
@@ -46,7 +46,7 @@ export class OrganizationsCLIController extends BaseCLIController {
       ? quickPickItems[0]
       : await vscode.window.showQuickPick(quickPickItems, {
         ignoreFocusOut: true,
-        title: 'Select DevCycle Organization',
+        title: `Select DevCycle Organization (${this.folder.name})`,
       })
     const selectedOrg = selectedItem?.value
     

--- a/src/cli/ProjectsCLIController.ts
+++ b/src/cli/ProjectsCLIController.ts
@@ -48,7 +48,7 @@ export class ProjectsCLIController extends BaseCLIController {
       ? projects[0]
       : await vscode.window.showQuickPick(projects, {
         ignoreFocusOut: true,
-        title: 'Select DevCycle Project',
+        title: `Select DevCycle Project (${this.folder.name})`,
       })
     
     if (!project) {


### PR DESCRIPTION
Include folder name when prompting for an org or project to give the user context