### PR TITLE
chore: Remove unused commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
         "icon": {
           "light": "media/togglebot.svg",
           "dark": "media/togglebot-white.svg"
-        },
-        "enablement": "devcycle-feature-flags.repoConfigured == false"
+        }
       },
       {
         "command": "devcycle-feature-flags.logout",
@@ -91,8 +90,7 @@
         "command": "devcycle-feature-flags.refresh-usages",
         "category": "DevCycle",
         "title": "Refresh Code Usages",
-        "icon": "$(refresh)",
-        "enablement": "devcycle-feature-flags.repoConfigured == true"
+        "icon": "$(refresh)"
       }
     ],
     "configuration": [

--- a/src/cli/AuthCLIController.ts
+++ b/src/cli/AuthCLIController.ts
@@ -17,13 +17,7 @@ export class AuthCLIController extends BaseCLIController {
   public async init() {
     showBusyMessage('Initializing DevCycle')
     const { code, error, output } = await this.execDvc('repo init')
-    if (code === 0) {
-      await vscode.commands.executeCommand(
-        'setContext',
-        'devcycle-feature-flags.loggedIn',
-        true,
-      )
-    } else {
+    if (code !== 0) {
       vscode.window.showErrorMessage(`Login failed ${error?.message}}`)
     }
     hideBusyMessage()
@@ -54,12 +48,6 @@ export class AuthCLIController extends BaseCLIController {
       const cliStatus = await this.status()
       const auth0UserId = cliStatus.a0UserId
       StateManager.setWorkspaceState(KEYS.AUTH0_USER_ID, auth0UserId)
-  
-      await vscode.commands.executeCommand(
-        'setContext',
-        'devcycle-feature-flags.loggedIn',
-        true,
-      )
       vscode.window.showInformationMessage('Logged in to DevCycle')
     } catch (e) {
       if (e instanceof Error) {
@@ -74,11 +62,6 @@ export class AuthCLIController extends BaseCLIController {
   public async logout() {
     const { code, error } = await this.execDvc('logout')
     if (code === 0) {
-      await vscode.commands.executeCommand(
-        'setContext',
-        'devcycle-feature-flags.loggedIn',
-        false,
-      )
       vscode.window.showInformationMessage('Logged out of DevCycle')
     } else {
       vscode.window.showInformationMessage(`Logout failed ${error?.message}}`)

--- a/src/cli/ProjectsCLIController.ts
+++ b/src/cli/ProjectsCLIController.ts
@@ -62,11 +62,6 @@ export class ProjectsCLIController extends BaseCLIController {
   protected async selectProject(project: string) {
     const { code, error } = await this.execDvc(`projects select --project=${project}`)
     if (code === 0) {
-      await vscode.commands.executeCommand(
-        'setContext',
-        'devcycle-feature-flags.repoConfigured',
-        true,
-      )
       StateManager.setFolderState(this.folder.name, KEYS.PROJECT_ID, project)
     } else {
       vscode.window.showErrorMessage(`Selecting project failed ${error?.message}}`)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,24 +75,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
           await executeRefreshUsagesCommand(folder)
         }
     }
-
-    const cli = new BaseCLIController(folder)
-    const status = await cli.status()
-    if (status.organization) {
-      // TODO: scope commands to folder
-      await vscode.commands.executeCommand(
-        'setContext',
-        'devcycle-feature-flags.repoConfigured',
-        status.repoConfigExists,
-      )
-      if (status.hasAccessToken) {
-        await vscode.commands.executeCommand(
-          'setContext',
-          'devcycle-feature-flags.loggedIn',
-          status.hasAccessToken,
-        )
-      }
-    }
   })
 
   // On Hover


### PR DESCRIPTION
Remove `loggedIn` and `repoConfigured` setContext commands:
`loggedIn` - set in multiple places but not used
`repoConfigured` - not relevant to enabling code usages, and not necessary to enable repo init (should be scoped by folder to actually work as intended)
