### PR TITLE
feat: Download cli on extension install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .idea
 .DS_STORE
 /src/analytics.ts
+dvc

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
     "@types/sinon": "^10.0.15",
+    "@types/tar": "^6.1.5",
     "@types/vscode": "^1.64.0",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
@@ -166,6 +167,7 @@
     "@types/vscode-webview": "^1.57.1",
     "axios": "^0.26.0",
     "change-case": "^4.1.2",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "tar": "^6.1.15"
   }
 }

--- a/src/cli/AuthCLIController.ts
+++ b/src/cli/AuthCLIController.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import { StateManager, KEYS } from '../StateManager'
 import { showBusyMessage, hideBusyMessage } from '../components/statusBarItem'
 import { Organization, OrganizationsCLIController } from './OrganizationsCLIController'
-import { loadRepoConfig } from '../utils'
+import { loadRepoConfig, showDebugOutput } from '../utils'
 import { BaseCLIController } from './BaseCLIController'
 import { executeRefreshUsagesCommand } from '../commands/refreshUsages'
 
@@ -51,7 +51,7 @@ export class AuthCLIController extends BaseCLIController {
       vscode.window.showInformationMessage('Logged in to DevCycle')
     } catch (e) {
       if (e instanceof Error) {
-        this.showDebugOutput(`Login failed ${e.message}`)
+        showDebugOutput(`Login failed ${e.message}`)
         throw e
       }
     } finally {

--- a/src/cli/BaseCLIController.test.ts
+++ b/src/cli/BaseCLIController.test.ts
@@ -4,6 +4,7 @@ import { describe, it, beforeEach, afterEach } from 'mocha'
 import sinon from 'sinon'
 import { BaseCLIController } from './BaseCLIController'
 import { StateManager } from '../StateManager'
+import utils from './utils'
 
 const mockSetState = sinon.stub()
 const mockGetState = sinon.stub().returns(null)
@@ -13,16 +14,19 @@ describe('BaseCLIController', () => {
   const baseCLIController = new BaseCLIController(folder)
   let execDvcStub: sinon.SinonStub
   let execShellStub: sinon.SinonStub
+  let getCliExecStub: sinon.SinonStub
 
   beforeEach(function() {
     StateManager.getFolderState = mockGetState
     StateManager.setFolderState = mockSetState
     mockGetState.returns(null)
+    getCliExecStub = sinon.stub(utils, 'getCliExec').resolves('dvc')
   })
 
   afterEach(function() {
     execDvcStub.restore()
     execShellStub?.restore()
+    getCliExecStub.restore()
   })
 
   describe('status', () => {
@@ -57,7 +61,7 @@ describe('BaseCLIController', () => {
 
   describe('execDvc', () => {
     it('calls CLI with command', async () => {
-      execShellStub = sinon.stub(baseCLIController, 'execShell').resolves({
+      execShellStub = sinon.stub(utils, 'execShell').resolves({
         code: 0,
         output: JSON.stringify({}),
         error: null,
@@ -70,7 +74,7 @@ describe('BaseCLIController', () => {
     })
 
     it('calls CLI with command including project ID', async () => {
-      execShellStub = sinon.stub(baseCLIController, 'execShell').resolves({
+      execShellStub = sinon.stub(utils, 'execShell').resolves({
         code: 0,
         output: JSON.stringify({}),
         error: null,
@@ -80,88 +84,6 @@ describe('BaseCLIController', () => {
       await baseCLIController.execDvc('some command')
 
       sinon.assert.calledWith(execShellStub, 'dvc some command --headless --caller vscode_extension --project project-id')
-    })
-  })
-
-  describe('isCliInstalled', () => {
-    it('returns true when CLI is installed', async () => {
-      execDvcStub = sinon.stub(baseCLIController, 'execDvc').resolves({
-        code: 0,
-        output: '@devcycle/cli/4.3.2 darwin-arm64 node-v16.17.0',
-        error: null,
-      })
-
-      const result = await baseCLIController.isCliInstalled()
-
-      sinon.assert.calledWith(execDvcStub, '--version')
-      expect(result).to.equal(true)
-    })
-
-    it('returns false when CLI returns an error', async () => {
-      execDvcStub = sinon.stub(baseCLIController, 'execDvc').resolves({
-        code: 0,
-        output: 'Error',
-        error: new Error(),
-      })
-
-      const result = await baseCLIController.isCliInstalled()
-
-      sinon.assert.calledWith(execDvcStub, '--version')
-      expect(result).to.equal(false)
-    })
-  })
-
-  describe('isCliMinVersion', () => {
-    it('returns true when CLI is above min version', async () => {
-      execDvcStub = sinon.stub(baseCLIController, 'execDvc').resolves({
-        code: 0,
-        output: '@devcycle/cli/9999.0.0 darwin-arm64 node-v16.17.0',
-        error: null,
-      })
-
-      const result = await baseCLIController.isCliMinVersion()
-
-      sinon.assert.calledWith(execDvcStub, '--version')
-      expect(result).to.equal(true)
-    })
-
-    it('returns false when CLI is not above min version', async () => {
-      execDvcStub = sinon.stub(baseCLIController, 'execDvc').resolves({
-        code: 0,
-        output: '@devcycle/cli/0.0.1 darwin-arm64 node-v16.17.0',
-        error: null,
-      })
-
-      const result = await baseCLIController.isCliMinVersion()
-
-      sinon.assert.calledWith(execDvcStub, '--version')
-      expect(result).to.equal(false)
-    })
-
-    it('returns false when CLI output is not a semver match', async () => {
-      execDvcStub = sinon.stub(baseCLIController, 'execDvc').resolves({
-        code: 0,
-        output: 'something random',
-        error: null,
-      })
-
-      const result = await baseCLIController.isCliMinVersion()
-
-      sinon.assert.calledWith(execDvcStub, '--version')
-      expect(result).to.equal(false)
-    })
-
-    it('returns false when CLI returns an error', async () => {
-      execDvcStub = sinon.stub(baseCLIController, 'execDvc').resolves({
-        code: 0,
-        output: 'Error',
-        error: new Error(),
-      })
-
-      const result = await baseCLIController.isCliMinVersion()
-
-      sinon.assert.calledWith(execDvcStub, '--version')
-      expect(result).to.equal(false)
     })
   })
 })

--- a/src/cli/utils/execShell.ts
+++ b/src/cli/utils/execShell.ts
@@ -1,0 +1,30 @@
+import * as cp from 'child_process'
+import { showDebugOutput } from '../../utils/showDebugOutput'
+
+type CommandResponse = {
+  output: string
+  error: Error | null
+  code: number
+}
+
+export function execShell(cmd: string, cwd: string) {
+  showDebugOutput(`Executing shell command ${cmd}`)
+  return new Promise<CommandResponse>((resolve, reject) => {
+    const cpOptions: cp.ExecOptions = { cwd }
+    cp.exec(cmd, cpOptions, (err, out) => {
+      if (err) {
+        resolve({
+          output: out,
+          error: err,
+          code: err.code || 0,
+        })
+      }
+      resolve({
+        output: out,
+        error: null,
+        code: 0,
+      })
+      return
+    })
+  })
+}

--- a/src/cli/utils/index.ts
+++ b/src/cli/utils/index.ts
@@ -1,0 +1,7 @@
+import * as loadCli from './loadCli'
+import * as execShell from './execShell'
+
+export default {
+  ...loadCli,
+  ...execShell
+}

--- a/src/cli/utils/loadCli.ts
+++ b/src/cli/utils/loadCli.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as fs from 'fs'
+import axios from 'axios'
+import tar from 'tar'
+import { CLI_VERSION } from '../../constants'
+import { showDebugOutput } from '../../utils/showDebugOutput'
+import { hideBusyMessage, showBusyMessage } from '../../components/statusBarItem'
+
+const CLI_ARTIFACTS = 'https://github.com/DevCycleHQ/cli/releases/download'
+const SUPPORTED_PLATFORMS = [
+  'darwin-arm64',
+  'linux-arm',
+  'win32-x64',
+]
+const OUTPUT_DIR = path.join(path.resolve(__dirname), '..')
+const CLI_ROOT = path.join(OUTPUT_DIR, 'dvc')
+const CLI_EXEC = path.join(CLI_ROOT, 'bin/run')
+
+function getArtifactName() {
+  const platform = `${process.platform}-${process.arch}`
+
+  if (!SUPPORTED_PLATFORMS.includes(platform)) {
+    throw new Error(`Unsupported platform: ${platform}`)
+  }
+
+  return `dvc-v${CLI_VERSION}-${platform}.tar.gz`
+}
+
+function getTarPath() {
+  return `${CLI_ARTIFACTS}/v${CLI_VERSION}/${getArtifactName()}`
+}
+
+function isCliLoaded() {
+  return (
+    fs.existsSync(CLI_EXEC) &&
+    fs.existsSync(path.join(CLI_ROOT, 'node_modules/@oclif/core/package.json'))
+  )
+}
+
+async function downloadCli() {
+  const sourceUrl = getTarPath()
+
+  const writeStream = tar.x({ cwd: OUTPUT_DIR })
+  const response = await axios.get(sourceUrl, {
+    responseType: 'stream',
+    headers: { 'accept-encoding': 'gzip' },
+  })
+  response.data.pipe(writeStream)
+
+  await new Promise<void>((resolve, reject) => {
+    writeStream.on('error', (err: Error) => {
+      showDebugOutput(`Failed to download ${sourceUrl}: ${err.message}`)
+      reject(err)
+    })
+
+    writeStream.on('close', () => resolve())
+  })
+  showDebugOutput('CLI Download complete!')
+}
+
+export async function loadCli() {
+  try {
+    if (!isCliLoaded()) {
+      showBusyMessage('Loading DevCycle CLI')
+      await downloadCli()
+    }
+  } catch (err) {
+    vscode.window.showErrorMessage('Error downloading DevCycle CLI')
+    throw err
+  } finally {
+    hideBusyMessage()
+  }
+  return CLI_EXEC
+}
+
+export async function getCliExec() {
+  return new Promise((resolve) => {
+    if (isCliLoaded()) {
+      resolve(CLI_EXEC)
+    } else {
+      setTimeout(() => resolve(getCliExec()), 500)
+    }
+  })
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const minimumCliVersion = '5.3.1'
+export const CLI_VERSION = '5.4.0'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 ;('use strict')
 import * as vscode from 'vscode'
 import { KEYS, StateManager } from './StateManager'
-import { AuthCLIController, BaseCLIController, getOrganizationId } from './cli'
+import { AuthCLIController, getOrganizationId } from './cli'
 import { autoLoginIfHaveCredentials } from './utils/credentials'
 
 import { getHoverString } from './components/hoverCard'
@@ -18,6 +18,7 @@ import {
 import { registerLogoutCommand } from './commands/logout'
 import { executeRefreshUsagesCommand, registerRefreshUsagesCommand } from './commands/refreshUsages'
 import { registerShowReferenceCommand } from './commands/showReference'
+import cliUtils from './cli/utils'
 
 Object.defineProperty(exports, '__esModule', { value: true })
 exports.deactivate = exports.activate = void 0
@@ -30,6 +31,8 @@ const SCHEME_FILE = {
 export const activate = async (context: vscode.ExtensionContext) => {
   StateManager.globalState = context.globalState
   StateManager.workspaceState = context.workspaceState
+
+  await cliUtils.loadCli()
 
   const [workspaceFolder] = vscode.workspace.workspaceFolders || []
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './loadRepoConfig'
+export * from './showDebugOutput'

--- a/src/utils/showDebugOutput.ts
+++ b/src/utils/showDebugOutput.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode'
+
+export function showDebugOutput(message: string) {
+  const debug = vscode.workspace
+    .getConfiguration('devcycle-feature-flags')
+    .get('debug')
+  if (debug) {
+    vscode.window.showInformationMessage(message)
+  }
+}

--- a/src/views/startup/StartupViewProvider.ts
+++ b/src/views/startup/StartupViewProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import { getNonce } from '../../utils/getNonce'
-import { setUpCliStartupView, setUpWorkspaceStartupView } from './utils/setUpViews'
+import { setUpWorkspaceStartupView } from './utils/setUpViews'
 
 export const enum STARTUP_VIEWS {
   CLI = 'cli',
@@ -118,17 +118,14 @@ export class StartupViewProvider implements vscode.WebviewViewProvider {
 
   private async checkView() {
     return {
-      shouldShowCliStartUpView: await setUpCliStartupView(),
       shouldShowWorkspaceView: setUpWorkspaceStartupView()
     }
   }
 
   private async refreshStartupView(webviewView: vscode.WebviewView) {
-    const { shouldShowCliStartUpView, shouldShowWorkspaceView } = await this.checkView()
+    const { shouldShowWorkspaceView } = await this.checkView()
     if (shouldShowWorkspaceView) {
       webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, STARTUP_VIEWS.WORKSPACE)
-    } else if (shouldShowCliStartUpView) {
-      webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, STARTUP_VIEWS.CLI)
     } else {
       await vscode.commands.executeCommand('devcycle-feature-flags.refresh-usages')
     }

--- a/src/views/startup/registerStartupViewProvider.ts
+++ b/src/views/startup/registerStartupViewProvider.ts
@@ -1,14 +1,12 @@
 import * as vscode from 'vscode'
 import { STARTUP_VIEWS, StartupViewProvider } from './StartupViewProvider'
-import { setUpCliStartupView, setUpWorkspaceStartupView } from './utils/setUpViews'
+import { setUpWorkspaceStartupView } from './utils/setUpViews'
 
 export async function registerStartupViewProvider(context: vscode.ExtensionContext) {
   let startupViewProvider: StartupViewProvider | undefined
   if (setUpWorkspaceStartupView()) {
     startupViewProvider = new StartupViewProvider(context.extensionUri, STARTUP_VIEWS.WORKSPACE)
-  } else if (await setUpCliStartupView()) {
-    startupViewProvider = new StartupViewProvider(context.extensionUri, STARTUP_VIEWS.CLI)
-  } 
+  }
 
   if (startupViewProvider) {
     context.subscriptions.push(

--- a/src/views/startup/utils/setUpViews.ts
+++ b/src/views/startup/utils/setUpViews.ts
@@ -1,30 +1,4 @@
 import * as vscode from 'vscode'
-import { BaseCLIController } from '../../../cli'
-import { minimumCliVersion } from '../../../constants'
-export const setUpCliStartupView = async () => {
-    const [folder] = vscode.workspace.workspaceFolders || []
-    const cli = new BaseCLIController(folder)
-    const isInstalled = await cli.isCliInstalled()
-    const isMinVersion = await cli.isCliMinVersion()
-    const shouldShowCliStartUpView = !(isInstalled && isMinVersion)
-    vscode.commands.executeCommand(
-        'setContext',
-        'devcycle-feature-flags.shouldShowCliView',
-        shouldShowCliStartUpView,
-    )
-
-    if (!isInstalled) {
-        vscode.window.showErrorMessage(
-            'In order to use DevCycle extension, please install DevCycle CLI.'
-        )
-    } else if (!isMinVersion) {
-        vscode.window.showErrorMessage(
-            `Your installed version of @devcycle/cli is outdated. Please update to version ${minimumCliVersion} or later.`
-          )
-    }
-
-    return shouldShowCliStartUpView
-}
 
 export const setUpWorkspaceStartupView = () => {
     const shouldShowWorkspaceView = !vscode.workspace.workspaceFolders

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,14 @@
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
 
+"@types/tar@^6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.5.tgz#90ccb3b6a35430e7427410d50eed564e85feaaff"
+  integrity sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==
+  dependencies:
+    "@types/node" "*"
+    minipass "^4.0.0"
+
 "@types/vscode-webview@^1.57.1":
   version "1.57.1"
   resolved "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.1.tgz"
@@ -906,6 +914,11 @@ chownr@^1.1.1:
   resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -1427,6 +1440,13 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2000,10 +2020,40 @@ minimist@^1.2.0, minimist@^1.2.3:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minipass@^3.0.0:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^4.0.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^9.2.1:
   version "9.2.2"
@@ -2715,6 +2765,18 @@ tar-stream@^2.1.4:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tar@^6.1.15:
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
+  integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 terser-webpack-plugin@^5.3.7:
   version "5.3.9"


### PR DESCRIPTION
Download DVC CLI from github release when the extension is activated (if it doesn't already exist)
- Read tarball artifact as a stream and write to file
- Extract file into extension root
- Remove view that prompts user to install CLI