### PR TITLE
add option to sort usages by key, created date, and updated date

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,13 +56,54 @@
         }
       ]
     },
+    "submenus": [
+      {
+          "id": "sortMenu",
+          "label": "Sort By",
+          "icon": "$(keybindings-sort)"
+      }
+    ],
     "menus": {
+      "view/item/context": [
+        {
+          "command": "devcycle-code-usages.sortByKey",
+          "when": "view == devcycle-code-usages"
+        },
+        {
+          "command": "devcycle-code-usages.sortByCreatedAt",
+          "when": "view == devcycle-code-usages"
+        },
+        {
+          "command": "devcycle-code-usages.sortByUpdatedAt",
+          "when": "view == devcycle-code-usages"
+        }
+      ],
+      "commandPalette": [{
+        "command": "devcycle-code-usages.sortMenu",
+        "when": "view == devcycle-code-usages.view",
+        "icon": "$(keybindings-sort)"
+      }],
+      "sortMenu": [
+          {
+              "command": "devcycle-code-usages.sortByKey"
+          },
+          {
+              "command": "devcycle-code-usages.sortByCreatedAt"
+          },
+          {
+              "command": "devcycle-code-usages.sortByUpdatedAt"
+          }
+      ],
       "editor/context": [],
       "view/title": [
         {
           "command": "devcycle-feature-flags.refresh-usages",
           "when": "view == devcycle-code-usages",
-          "group": "navigation"
+          "group": "navigation@1"
+        },{
+          "submenu": "sortMenu",
+          "when": "view == devcycle-code-usages",
+          "group": "navigation@2"
         }
       ]
     },
@@ -91,7 +132,28 @@
         "category": "DevCycle",
         "title": "Refresh Code Usages",
         "icon": "$(refresh)"
-      }
+      },
+      {
+        "command": "devcycle-code-usages.sortByKey",
+        "title": "Sort by Key",
+        "category": "DevCycle Code Usages"
+      },
+      {
+        "command": "devcycle-code-usages.sortByCreatedAt",
+        "title": "Sort by Creation Date",
+        "category": "DevCycle Code Usages"
+      },
+      {
+        "command": "devcycle-code-usages.sortByUpdatedAt",
+        "title": "Sort by Updated Date",
+        "category": "DevCycle Code Usages"
+      },
+      {
+        "command": "devcycle-code-usages.sortMenu",
+        "title": "Sort By",
+        "category": "DevCycle",
+        "icon": "$(keybindings-sort)"
+    }
     ],
     "configuration": [
       {

--- a/src/cli/VariablesCLIController.ts
+++ b/src/cli/VariablesCLIController.ts
@@ -8,6 +8,8 @@ export type Variable = {
   _id: string
   name: string
   description?: string
+  createdAt: string
+  updatedAt: string
   status: 'active' | 'archived'
 }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,3 +1,4 @@
 export * from './init'
 export * from './usagesNodeClicked'
 export * from './openLink'
+export * from './sortUsages'

--- a/src/commands/sortUsages/constants.ts
+++ b/src/commands/sortUsages/constants.ts
@@ -1,0 +1,7 @@
+export enum SortCriteria {
+    KEY = 'key',
+    CREATED_AT = 'createdAt',
+    UPDATED_AT = 'updatedAt',
+}
+
+export const COMMAND_SORT_USAGES = 'devcycle-feature-flags.sort-usages'

--- a/src/commands/sortUsages/executeSortUsagesCommand.ts
+++ b/src/commands/sortUsages/executeSortUsagesCommand.ts
@@ -1,0 +1,6 @@
+import * as vscode from 'vscode'
+import { COMMAND_SORT_USAGES } from './constants'
+
+export async function executeSortUsagesCommand(folder?: vscode.WorkspaceFolder) {
+  await vscode.commands.executeCommand(COMMAND_SORT_USAGES, folder)
+}

--- a/src/commands/sortUsages/index.ts
+++ b/src/commands/sortUsages/index.ts
@@ -1,0 +1,3 @@
+export * from './registerSortUsagesCommand'
+export * from './constants'
+export * from './executeSortUsagesCommand'

--- a/src/commands/sortUsages/registerSortUsagesCommand.ts
+++ b/src/commands/sortUsages/registerSortUsagesCommand.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode'
+import { SortCriteria } from './constants'
+import { UsagesTreeProvider } from '../../views/usages'
+
+export const registerSortUsagesCommand = (
+    context: vscode.ExtensionContext,
+    usagesDataProvider: UsagesTreeProvider
+  ) => {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('devcycle-code-usages.sortByKey', async () => {
+            usagesDataProvider.sortKey = SortCriteria.KEY
+            usagesDataProvider.sortData()
+
+        })
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand('devcycle-code-usages.sortByCreatedAt', async () => {
+            usagesDataProvider.sortKey = SortCriteria.CREATED_AT
+            usagesDataProvider.sortData()
+
+        })
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand('devcycle-code-usages.sortByUpdatedAt', async () => {
+            usagesDataProvider.sortKey = SortCriteria.UPDATED_AT
+            usagesDataProvider.sortData()
+
+        })
+    )
+}

--- a/src/commands/sortUsages/registerSortUsagesCommand.ts
+++ b/src/commands/sortUsages/registerSortUsagesCommand.ts
@@ -8,23 +8,28 @@ export const registerSortUsagesCommand = (
   ) => {
     context.subscriptions.push(
         vscode.commands.registerCommand('devcycle-code-usages.sortByKey', async () => {
-            usagesDataProvider.sortKey = SortCriteria.KEY
-            usagesDataProvider.sortData()
-
+            setSortKeyAndSort(usagesDataProvider, SortCriteria.KEY)
         })
     )
     context.subscriptions.push(
         vscode.commands.registerCommand('devcycle-code-usages.sortByCreatedAt', async () => {
-            usagesDataProvider.sortKey = SortCriteria.CREATED_AT
-            usagesDataProvider.sortData()
+            setSortKeyAndSort(usagesDataProvider, SortCriteria.CREATED_AT)
 
         })
     )
     context.subscriptions.push(
         vscode.commands.registerCommand('devcycle-code-usages.sortByUpdatedAt', async () => {
-            usagesDataProvider.sortKey = SortCriteria.UPDATED_AT
-            usagesDataProvider.sortData()
-
+            setSortKeyAndSort(usagesDataProvider, SortCriteria.UPDATED_AT)
         })
     )
+}
+
+const setSortKeyAndSort = (usagesDataProvider: UsagesTreeProvider, criteria: SortCriteria) => {
+    if (usagesDataProvider.sortKey === criteria) {
+        usagesDataProvider.sortAsc = !usagesDataProvider.sortAsc
+    } else {
+        usagesDataProvider.sortAsc = true
+    }
+    usagesDataProvider.sortKey = criteria
+    usagesDataProvider.sortData()
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,8 @@ import { registerUsagesViewProvider } from './views/usages'
 import {
   registerInitCommand,
   registerUsagesNodeClickedCommand,
-  registerOpenLinkCommand
+  registerOpenLinkCommand,
+  registerSortUsagesCommand
 } from './commands'
 import { registerLogoutCommand } from './commands/logout'
 import { executeRefreshUsagesCommand, registerRefreshUsagesCommand } from './commands/refreshUsages'
@@ -66,6 +67,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
   await registerOpenLinkCommand(context)
   await registerLogoutCommand(context)
   await registerRefreshUsagesCommand(context, usagesDataProvider)
+  await registerSortUsagesCommand(context, usagesDataProvider)
   await registerShowReferenceCommand(context)
 
   vscode.workspace.workspaceFolders?.forEach(async (folder) => {

--- a/src/views/usages/UsagesTree/CodeUsageNode.ts
+++ b/src/views/usages/UsagesTree/CodeUsageNode.ts
@@ -49,6 +49,20 @@ export class CodeUsageNode extends vscode.TreeItem {
           [],
           variable.status,
         ),
+        new CodeUsageNode(
+          key + ':createdAt',
+          `Created Date`,
+          'detail',
+          [],
+          variable.createdAt,
+        ),
+        new CodeUsageNode(
+          key + ':updatedAt',
+          `Updated Date`,
+          'detail',
+          [],
+          variable.updatedAt,
+        ),
         new CodeUsageNode(key + ':id', `ID`, 'detail', [], variable._id),
         new CodeUsageNode(
           key + ':feature',

--- a/src/views/usages/UsagesTree/UsagesTreeProvider.ts
+++ b/src/views/usages/UsagesTree/UsagesTreeProvider.ts
@@ -22,7 +22,7 @@ export class UsagesTreeProvider
   private flagsByFolder: Record<string, CodeUsageNode[]> = {}
   private isRefreshing: Record<string, boolean> = {}
   sortKey: 'key' | 'createdAt' | 'updatedAt' = 'key'
-
+  sortAsc: boolean = true
   
   constructor(
     private context: vscode.ExtensionContext,
@@ -66,14 +66,15 @@ export class UsagesTreeProvider
       if (criteria === 'key') {
         return node.key
       }
-      const detailNode = node.children[0].children.find(child => child.key.includes(`:${criteria}`));
-      return detailNode?.description || '';
-    };
+      const detailNode = node.children[0].children.find(child => child.key.includes(`:${criteria}`))
+      return detailNode?.description || ''
+    }
     
-    const aValue = getSortValue(a, this.sortKey);
-    const bValue = getSortValue(b, this.sortKey);
+    const aValue = getSortValue(a, this.sortKey)
+    const bValue = getSortValue(b, this.sortKey)
 
-    return aValue > bValue ? 1 : -1;
+    const val = aValue > bValue ? 1 : -1
+    return this.sortAsc ? val : val * -1
   }
 
   async refreshAll(): Promise<void> {


### PR DESCRIPTION
- Add sort button to the sidebar view title bar
- That button has a dropdown containing a submenu with the three different sorting criteria 
- Add the createdAt and updatedAt fields as children in the usages tree so that they can be used for sorting (and also be visible to the user)

EDIT: 
- will now sort descending if you sort by the same criteria twice in a row
- 
TODO still:
- Add some tests (will probably need to refactor the sorting login out into a utility function because Instantiating the UsagesTreeProvider class in a test is gonna be a whole separate can of worms)