### PR TITLE
fix: Update installed cli version if it  does not match pinned version

### DIFF
--- a/src/cli/utils/loadCli.ts
+++ b/src/cli/utils/loadCli.ts
@@ -35,10 +35,17 @@ function getTarPath() {
 }
 
 function isCliLoaded() {
-  return (
-    fs.existsSync(CLI_EXEC) &&
-    fs.existsSync(path.join(CLI_ROOT, 'node_modules/@oclif/core/package.json'))
-  )
+  try {
+    const manifestPath = path.join(CLI_ROOT, 'oclif.manifest.json')
+    return (
+      fs.existsSync(CLI_EXEC) &&
+      fs.existsSync(path.join(CLI_ROOT, 'node_modules/@oclif/core/package.json')) &&
+      fs.existsSync(manifestPath) &&
+      JSON.parse(fs.readFileSync(manifestPath, 'utf8')).version === CLI_VERSION
+    )
+  } catch (err) {
+    return false
+  }
 }
 
 async function downloadCli() {


### PR DESCRIPTION
If the installed cli version does not match the version pinned in the release, consider the cli not installed and load the pinned version