### PR TITLE
feat: Only show code usages in variables list

### DIFF
--- a/src/cli/VariablesCLIController.test.ts
+++ b/src/cli/VariablesCLIController.test.ts
@@ -68,6 +68,20 @@ describe('VariablesCLIController', () => {
       }
       expect(result).to.deep.equal(expectedCLIResult)
     })
+
+    it('returns an empty map when CLI returns an error', async () => {
+      execDvcStub.restore()
+      execDvcStub = sinon.stub(variablesCLIController, 'execDvc').resolves({
+        code: 1,
+        output: '',
+        error: new Error(),
+      })
+
+      const result = await variablesCLIController.getAllVariables()
+
+      assert.isTrue(execDvcStub.calledWithExactly('variables get'))
+      expect(result).to.deep.equal({})
+    })
   })
 
   describe('getVariable', () => {

--- a/src/cli/VariablesCLIController.ts
+++ b/src/cli/VariablesCLIController.ts
@@ -52,7 +52,7 @@ export class VariablesCLIController extends BaseCLIController {
       vscode.window.showErrorMessage(
         `Retrieving variables failed: ${error?.message}}`,
       )
-      return []
+      return {}
     } else {
       const variables = JSON.parse(output) as Variable[]
       const variableMap = variables.reduce((result, currentVariable) => {


### PR DESCRIPTION
Only show code usages in the variables list (not all variables from the API)

Note: the getAllVariables call still only returns the first 100 variables, so many variables will be incorrectly flagged as not in devcycle — this will be fixed in a follow up PR