### PR TITLE
fix: Use per-page param to fetch 1000 variables

### DIFF
--- a/src/cli/VariablesCLIController.test.ts
+++ b/src/cli/VariablesCLIController.test.ts
@@ -62,7 +62,7 @@ describe('VariablesCLIController', () => {
     it('should use CLI to fetch variables if none cached', async () => {
       const result = await variablesCLIController.getAllVariables()
 
-      assert.isTrue(execDvcStub.calledWithExactly('variables get'))
+      assert.isTrue(execDvcStub.calledWithExactly('variables get --per-page 1000'))
       const expectedCLIResult = {
         'cli-variable': mockCLIVariables[0],
       }
@@ -79,7 +79,7 @@ describe('VariablesCLIController', () => {
 
       const result = await variablesCLIController.getAllVariables()
 
-      assert.isTrue(execDvcStub.calledWithExactly('variables get'))
+      assert.isTrue(execDvcStub.calledWithExactly('variables get --per-page 1000'))
       expect(result).to.deep.equal({})
     })
   })

--- a/src/cli/VariablesCLIController.ts
+++ b/src/cli/VariablesCLIController.ts
@@ -47,7 +47,7 @@ export class VariablesCLIController extends BaseCLIController {
     if (variables) {
       return variables
     }
-    const { code, error, output } = await this.execDvc('variables get')
+    const { code, error, output } = await this.execDvc('variables get --per-page 1000')
     if (code !== 0) {
       vscode.window.showErrorMessage(
         `Retrieving variables failed: ${error?.message}}`,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '5.4.3'
+export const CLI_VERSION = '5.5.0'


### PR DESCRIPTION
Use CLI pagination params to fetch 1000 variables rather than default 100

Depends on CLI release of https://github.com/DevCycleHQ/cli/pull/264