### PR TITLE
fix: Prevent multiple CLI requests when initializing extension

### DIFF
--- a/.devcycle/config.yml
+++ b/.devcycle/config.yml
@@ -1,0 +1,5 @@
+org:
+  id: org_tPyJN5dvNNirKar7
+  name: devcycle
+  display_name: DevCycle
+project: vscode-extension

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '5.5.0'
+export const CLI_VERSION = '5.6.0'

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -1,10 +1,9 @@
 import * as vscode from 'vscode'
 import { BaseCLIController } from '../cli'
 import { KEYS, StateManager } from '../StateManager'
-import { loadRepoConfig } from './loadRepoConfig'
+import { RepoConfig } from './loadRepoConfig'
 
-export async function autoLoginIfHaveCredentials(folder: vscode.WorkspaceFolder) {
-  const repoConfig = await loadRepoConfig(folder)
+export async function autoLoginIfHaveCredentials(folder: vscode.WorkspaceFolder, repoConfig: RepoConfig) {
   const projectId = repoConfig.project || await StateManager.getFolderState(folder.name, KEYS.PROJECT_ID)
   const organization = repoConfig.org || await StateManager.getFolderState(folder.name, KEYS.ORGANIZATION)
 


### PR DESCRIPTION
If the extension loads with an expired access token, the CLI will exchange the refresh token for a new access token. Currently multiple `dvc status` requests are sent simultaneously, which results in all but the first failing (because the refresh token is invalidated after it's used once).
- Load initial repo configs synchronously to allow the token to be refreshed if necessary
- Add repo config
- Bump CLI version