### PR TITLE
fix: settings button shows only on home view

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
         },
         {
           "command": "devcycle-feature-flags.openSettings",
+          "when": "view == devcycle-home",
           "group": "navigation@3"
         }
       ]


### PR DESCRIPTION
- the settings(gear) icon was showing everywhere in vscode, fixed by putting it on the home view
![settings](https://github.com/DevCycleHQ/vscode-extension/assets/69351113/fb4e51fe-e535-4624-ba66-778a5879cb96)
