### PR TITLE
feat: Refresh code usages on file save

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,10 +228,10 @@
             "default": true,
             "description": "Initialize repository with a DevCycle configuration file on login."
           },
-          "devcycle-feature-flags.usagesOnWorkspaceOpen": {
+          "devcycle-feature-flags.refreshUsagesOnSave": {
             "type": "boolean",
             "default": true,
-            "description": "Automatically check for code usages when a configured workspace is opened."
+            "description": "Automatically check for code usages when a file is saved."
           },
           "devcycle-feature-flags.debug": {
             "type": "boolean",

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -79,7 +79,7 @@ export class StateManager {
   static setFolderState(folder: string, key: KEYS.FEATURE_CONFIGURATIONS, value: Record<string, FeatureConfiguration[]> | undefined): Thenable<void>
   static setFolderState(folder: string, key: KEYS.ENVIRONMENTS, value: Record<string, Environment> | undefined): Thenable<void>
   static setFolderState(folder: string, key: KEYS.ORGANIZATION, value: Organization | undefined): Thenable<void>
-  static setFolderState(folder: string, key: KEYS.CODE_USAGE_KEYS, value: string[] | undefined): Thenable<void>
+  static setFolderState(folder: string, key: KEYS.CODE_USAGE_KEYS, value: Record<string, boolean> | undefined): Thenable<void>
   static setFolderState(folder: string, key: string, value: any) {
     return this.workspaceState.update(`${folder}.${key}`, value)
   }
@@ -93,7 +93,7 @@ export class StateManager {
   static getFolderState(folder: string, key: KEYS.ENVIRONMENTS): Record<string, Environment> | undefined
   static getFolderState(folder: string, key: KEYS.ORGANIZATION): Organization | undefined
   static getFolderState(folder: string, key: KEYS.SEND_METRICS_PROMPTED): boolean | undefined
-  static getFolderState(folder: string, key: KEYS.CODE_USAGE_KEYS): string[] | undefined
+  static getFolderState(folder: string, key: KEYS.CODE_USAGE_KEYS): Record<string, boolean> | undefined
   static getFolderState(folder: string, key: string) {
     return this.workspaceState.get(`${folder}.${key}`)
   }

--- a/src/cli/UsagesCLIController.test.ts
+++ b/src/cli/UsagesCLIController.test.ts
@@ -42,7 +42,7 @@ describe('UsagesCLIController', () => {
 
       assert.isTrue(execDvcStub.calledWithExactly('usages --format=json'))
       expect(result).to.deep.equal(mockCodeUsages)
-      sinon.assert.calledWith(mockSetState, 'test-folder', 'code_usage_keys', ['cli-variable'])
+      sinon.assert.calledWith(mockSetState, 'test-folder', 'code_usage_keys', { 'cli-variable': true })
     })
   })
 })

--- a/src/cli/UsagesCLIController.ts
+++ b/src/cli/UsagesCLIController.ts
@@ -31,7 +31,11 @@ export class UsagesCLIController extends BaseCLIController {
     
     const matches = JSON.parse(output) as JSONMatch[]
     hideBusyMessage()
-    StateManager.setFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS, matches.map((match) => match.key))
+    const codeUsageKeys = matches.reduce((map, match) => {
+      map[match.key] = true
+      return map
+    }, {} as Record<string, boolean>)
+    StateManager.setFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS, codeUsageKeys)
     return matches
   }
 }

--- a/src/components/hoverCard.ts
+++ b/src/components/hoverCard.ts
@@ -1,41 +1,55 @@
 import * as vscode from 'vscode'
 import { CombinedVariableData, getCombinedVariableDetails } from '../cli'
+import { KEYS, StateManager } from '../StateManager'
+
+const possibleValuesCommand = ''
+const usagesCommand = 'command:devcycle-feature-flags.openUsagesView'
+const detailsCommand = ''
 
 export const getHoverString = async (
   folder: vscode.WorkspaceFolder,
-  variableKey: string
+  variableKey: string,
 ) => {
-  const variableData = await getCombinedVariableDetails(folder, variableKey)
+  const apiVariables = StateManager.getFolderState(folder.name, KEYS.VARIABLES) || {}
+  const variableData = apiVariables[variableKey]
+    ? await getCombinedVariableDetails(folder, variableKey)
+    : undefined
 
   const hoverString = new vscode.MarkdownString('')
   hoverString.isTrusted = true
   hoverString.supportHtml = true
 
-  if (variableData) {
-    hoverString.appendMarkdown(getHTML(variableData))
-  }
+  hoverString.appendMarkdown(
+    variableData ? getVariableHTML(variableData) : getVariableNotFoundHTML(variableKey)
+  )
   return hoverString
 }
 
-const getHTML = (
+const getVariableHTML = (
   variableData: CombinedVariableData
 ) => {
   const { variable, feature } = variableData
-
-  const possibleValuesCommand = ''
-  const usagesCommand = 'command:devcycle-feature-flags.openUsagesView'
-  const detailsCommand = ''
 
   const possibleValuesLink = generateLinkToSidebar('codicon-preserve-case', 'Possible Values', possibleValuesCommand)
   const usagesLink = generateLinkToSidebar('codicon-symbol-keyword', 'Usages', usagesCommand, { variableKey: variable.key })
   const detailsLink = generateLinkToSidebar('codicon-search', 'Details', detailsCommand)
 
   return `
-<b>DevCycle Variable:</b> ${variable.name} \n
-${feature && `From feature: ${feature.name}`} \n 
---------
-${possibleValuesLink}${usagesLink}${detailsLink}
-    `
+  <b>DevCycle Variable:</b> ${variable.name} \n
+  ${feature && `Feature: ${feature.name}`} \n 
+  --------
+  ${possibleValuesLink}${usagesLink}${detailsLink}
+`
+}
+
+const getVariableNotFoundHTML = (variableKey: string) => {
+  const usagesLink = generateLinkToSidebar('codicon-symbol-keyword', 'Usages', usagesCommand, { variableKey })
+
+  return `
+  <b>Variable:</b> ${variableKey} (not found in DevCycle)\n
+  --------
+  ${usagesLink}
+`
 }
 
 const generateLinkToSidebar = (iconClass: string, label: string, command: string, param?: unknown) => {

--- a/src/views/usages/UsagesTree/UsagesTreeProvider.ts
+++ b/src/views/usages/UsagesTree/UsagesTreeProvider.ts
@@ -58,14 +58,16 @@ export class UsagesTreeProvider
     )
   }
 
-  async refresh(folder: vscode.WorkspaceFolder): Promise<void> {
+  async refresh(folder: vscode.WorkspaceFolder, showLoading: boolean = true): Promise<void> {
     if (this.isRefreshing[folder.name]) {
       return
     }
 
     this.isRefreshing[folder.name] = true
     this.flagsByFolder[folder.name] = []
-    this._onDidChangeTreeData.fire(undefined)
+    if (showLoading) {
+      this._onDidChangeTreeData.fire(undefined)
+    }
 
     // Use withProgress to show a progress indicator
     await vscode.window.withProgress(


### PR DESCRIPTION
- Add a setting (defaulting to true) to refresh code usages after a file is changed. Now when a user adds a variable usage the hover card will appear after saving
- Update codes usage keys in StateManager to be an object rather than an array so that it's a constant lookup
- Display the hover card any time a code usage is found (even if variable doesn't exist in the api)