### PR TITLE
feat: multiple folders in inspector view

### DIFF
--- a/media/styles/inspector.css
+++ b/media/styles/inspector.css
@@ -37,27 +37,27 @@ input[type='checkbox'] {
   padding: 5px 0 0;
 }
 
-.dropdown-container {
+.multiple-folder-container {
   box-sizing: border-box;
   display: flex;
-  justify-content: space-between;
+  justify-content: left;
   align-items: center;
-  max-width: 260px;
 }
 
-.dropdown-container label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--vscode-foreground);
-  font-size: var(--vscode-font-size);
-  line-height: normal;
+.multiple-folder-container i, span {
+  margin-right: 0.5rem;
+}
+
+.inspector-dropdown-folder {
+  margin-right: 0.3rem;
+  width: auto;
+  flex-grow: 1;
 }
 
 .inspector-dropdown-container {
+  margin-top: 0.3rem;
   box-sizing: border-box;
   display: flex;
-  justify-content: right;
   align-items: center;
 }
 

--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
           "command": "devcycle-feature-flags.openSettings",
           "when": "view == devcycle-home",
           "group": "navigation@3"
+        },
+        {
+          "command": "devcycle-feature-flags.refresh-inspector",
+          "when": "view == devcycle-inspector",
+          "group": "navigation@1"
         }
       ]
     },
@@ -212,6 +217,12 @@
         "command": "devcycle-feature-flags.copyToClipboard",
         "title": "Copy to clipboard",
         "icon": "$(copy)"
+      },
+      {
+        "command": "devcycle-feature-flags.refresh-inspector",
+        "category": "DevCycle",
+        "title": "Refresh Inspector",
+        "icon": "$(refresh)"
       }
     ],
     "configuration": [

--- a/src/cli/UsagesCLIController.ts
+++ b/src/cli/UsagesCLIController.ts
@@ -25,6 +25,16 @@ export type Range = {
 }
 
 export class UsagesCLIController extends BaseCLIController {
+  
+  public async usagesKeys() {
+    const usagesKeys = StateManager.getFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS)
+    if (usagesKeys) {
+      return usagesKeys
+    }
+    await this.usages()
+    return StateManager.getFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS) || {}
+  }
+
   public async usages(): Promise<JSONMatch[]> {
     showBusyMessage('Finding Devcycle code usages')
     const { output } = await this.execDvc('usages --format=json')

--- a/src/commands/openCodeUsagesView/registerOpenUsagesViewCommand.ts
+++ b/src/commands/openCodeUsagesView/registerOpenUsagesViewCommand.ts
@@ -11,9 +11,9 @@ export async function registerOpenUsagesViewCommand(
     context.subscriptions.push(
         vscode.commands.registerCommand(
             OPEN_USAGES_VIEW,
-            async ({ variableKey }: { variableKey: string }) => {
+            async ({ variableKey, folderUri }: { variableKey: string, folderUri?: string }) => {
                 try {
-                    const activeDocumentUri = vscode.window.activeTextEditor?.document.uri
+                    const activeDocumentUri = (folderUri && vscode.Uri.parse(folderUri)) || vscode.window.activeTextEditor?.document.uri
                     const currentFolder = activeDocumentUri ? vscode.workspace.getWorkspaceFolder(activeDocumentUri) : undefined
                 
                     if (!currentFolder) {

--- a/src/commands/refreshAll/registerRefreshAllCommand.ts
+++ b/src/commands/refreshAll/registerRefreshAllCommand.ts
@@ -3,10 +3,11 @@ import { COMMAND_REFRESH_ALL } from './constants'
 import { StateManager } from '../../StateManager'
 import { UsagesTreeProvider } from '../../views/usages'
 import { EnvironmentsTreeProvider } from '../../views/environments'
+import { InspectorViewProvider } from '../../views/inspector'
 
 export async function registerRefreshAllCommand(
   context: vscode.ExtensionContext,
-  providers: (UsagesTreeProvider | EnvironmentsTreeProvider)[]
+  providers: (UsagesTreeProvider | EnvironmentsTreeProvider | InspectorViewProvider)[]
 ) {
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/src/commands/refreshInspector/constants.ts
+++ b/src/commands/refreshInspector/constants.ts
@@ -1,0 +1,1 @@
+export const COMMAND_REFRESH_INSPECTOR = 'devcycle-feature-flags.refresh-inspector'

--- a/src/commands/refreshInspector/index.ts
+++ b/src/commands/refreshInspector/index.ts
@@ -1,0 +1,2 @@
+export * from './registerInspectorCommand'
+export * from './constants'

--- a/src/commands/refreshInspector/registerInspectorCommand.ts
+++ b/src/commands/refreshInspector/registerInspectorCommand.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode'
+import { COMMAND_REFRESH_INSPECTOR } from './constants'
+import { InspectorViewProvider } from '../../views/inspector'
+
+export async function registerRefreshInspectorCommand(
+  context: vscode.ExtensionContext,
+  inspectorViewProvider: InspectorViewProvider
+) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      COMMAND_REFRESH_INSPECTOR,
+      async ({ folder }: { folder?: vscode.WorkspaceFolder } = {}) => {
+        await inspectorViewProvider.refreshAll()
+      },
+    ),
+  )
+}

--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -1,18 +1,19 @@
 import * as vscode from 'vscode'
 import { getNonce } from '../../utils/getNonce'
-import { Feature, FeaturesCLIController, JSONMatch, OrganizationsCLIController, ProjectsCLIController, UsagesCLIController, Variable, VariablesCLIController, getOrganizationId } from '../../cli'
+import { Feature, FeaturesCLIController, UsagesCLIController, Variable, VariablesCLIController, getOrganizationId } from '../../cli'
 import { KEYS, StateManager } from '../../StateManager'
 import { OPEN_USAGES_VIEW } from '../../commands'
-import { OPEN_DVC_SETTINGS } from '../../commands/openSettings/constants'
 
 type InspectorViewMessage =
-  | { type: 'variableOrFeature', value: 'Variable' | 'Feature', folderIndex: number }
-  | { type: 'key', value: string, folderIndex: number }
+  | { type: 'variableOrFeature', value: 'Variable' | 'Feature' }
+  | { type: 'key', value: string }
+  | { type: 'folder', value: number }
 
 export class InspectorViewProvider implements vscode.WebviewViewProvider {
     _view?: vscode.WebviewView
     _doc?: vscode.TextDocument
 
+    selectedFolder: vscode.WorkspaceFolder | undefined
     selectedType: 'Variable' | 'Feature'
     selectedKey: string
 
@@ -20,33 +21,41 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
     orderedVariables: Variable[] = []
     features: Record<string, Feature> = {}
     matches: Record<string, boolean> = {}
+    isRefreshing: boolean = false
 
   constructor(private readonly _extensionUri: vscode.Uri) {
     this.selectedType = 'Variable'
     this.selectedKey = ''
+    this.selectedFolder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]
 
     const folder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]
     if (!folder) {
       return
     }
-
-    this.matches = StateManager.getFolderState(folder.name, KEYS.CODE_USAGE_KEYS) || {}
     
-    const variablesCLIController = new VariablesCLIController(folder)
-    const featuresCLIController = new FeaturesCLIController(folder)
+    this.initializeFeaturesAndVariables(folder)
+  }
 
-    variablesCLIController.getAllVariables().then((variables) => {
-      this.variables = variables
+  private async initializeFeaturesAndVariables(folder: vscode.WorkspaceFolder) {
+    try {
+      const variablesCLIController = new VariablesCLIController(folder)
+      const featuresCLIController = new FeaturesCLIController(folder)
+      const usagesCLIController = new UsagesCLIController(folder)
+      
+      this.variables = await variablesCLIController.getAllVariables()
       this.orderedVariables = Object.values(this.variables).sort((a: Variable, b: Variable) => a.name.localeCompare(b.name))
+      this.features = await featuresCLIController.getAllFeatures()
+      this.matches = await usagesCLIController.usagesKeys()
+      
       // default to the alphabetically first variable in variable list
       if (Object.values(this.variables).length) {
         this.selectedKey = this.orderedVariables[0].key
       }
-    })
-
-    featuresCLIController.getAllFeatures().then((features) => {
-      this.features = features
-    })
+    } catch (e) {
+      vscode.window.showErrorMessage(
+        `Error initializing features and variables in inspector: ${e}`,
+      )
+    }
   }
 
   public async resolveWebviewView(webviewView: vscode.WebviewView) {
@@ -61,9 +70,6 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
     webviewView.webview.html = await this._getHtmlForWebview(webviewView.webview)
 
     webviewView.webview.onDidReceiveMessage(async (data: InspectorViewMessage) => {
-      const folder = vscode.workspace.workspaceFolders?.[data.folderIndex]
-      if (!folder) { return }
-
       if (data.type === 'variableOrFeature') {
         this.selectedType = data.value
         if (this.selectedType === 'Variable') {
@@ -75,16 +81,48 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
         }
       } else if (data.type === 'key') {
         this.selectedKey = data.value
+      } else if (data.type === 'folder') {
+        this.selectedFolder = vscode.workspace.workspaceFolders?.[data.value] as vscode.WorkspaceFolder
+        this.matches = StateManager.getFolderState(this.selectedFolder.name, KEYS.CODE_USAGE_KEYS) || {}
       }
       webviewView.webview.html = await this._getHtmlForWebview(webviewView.webview)
     })
+  }
+
+  public async refreshAll() {
+    if (this.isRefreshing) {
+      return
+    }
+
+    this.isRefreshing = true
+
+    // Use withProgress to show a progress indicator
+    await vscode.window.withProgress(
+      {
+        location: { viewId: 'devcycle-inspector' },
+      },
+      async () => {
+        const folder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]
+        if (!folder || !this._view) {
+          return
+        }
+        this.selectedFolder = folder
+        await this.initializeFeaturesAndVariables(folder)
+        this._view.webview.html = await this._getHtmlForWebview(this._view.webview)
+      }
+    )
+    this.isRefreshing = false
+  }
+
+  public async refresh(folder: vscode.WorkspaceFolder) {
+    this.refreshAll()
   }
 
   public revive(panel: vscode.WebviewView) {
     this._view = panel
   }
 
-  private async getBodyHtml(folder: vscode.WorkspaceFolder): Promise<string> {
+  private async getBodyHtml(): Promise<string> {
     const inspectorOptions = ['Variable', 'Feature'].map((option) => (
       `<vscode-option value="${option}"${option === this.selectedType ? ' selected' : '' }>${option}</vscode-option>`
     ))
@@ -93,60 +131,25 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
       `<vscode-option value="${variable.key}"${variable.key === this.selectedKey ? ' selected' : '' }>${variable.key}</vscode-option>`
     )) || []
 
-    const featureOptions = Object.values(this.features).sort().map((feature) => (
+    const featureOptions = this.features && Object.values(this.features).sort((a, b) =>  a.name.localeCompare(b.name)).map((feature) => (
       `<vscode-option value="${feature._id}"${feature._id === this.selectedKey ? ' selected' : '' }>${feature.key}</vscode-option>`
     )) || []
 
-    const name = this.selectedType === 'Variable' ? 
-      this.variables[this.selectedKey]?.name : 
-      this.features[this.selectedKey]?.name
-    const key = this.selectedType === 'Variable' ? 
-      this.variables[this.selectedKey]?.key : 
-      this.features[this.selectedKey]?.key
-    const featureName = this.selectedType === 'Variable' &&
-      Object.values(this.features).find((feature) => feature._id === (this.variables[this.selectedKey] as Variable)?._feature)?.name
-
-    const getAllPossibleValuesForVariable = (variable?: Variable) => {
-      if (!variable || !this.features[variable._feature]) {
-        return {}
-      }
-      const variableVariationValueMap: Record<string, unknown> = {}
-      const feature = this.features[variable._feature]
-      for (const variation of feature.variations || []) {
-        variableVariationValueMap[variation.name] = variation.variables?.[variable.key]
-      }
-      return variableVariationValueMap
+    const possibleValues = this.getPossibleValuesHTML()
+    const variableKeysInFeature = this.getVariableKeysInFeatureHTML()
+    if (!this.selectedFolder) {
+      return ''
     }
-    const possibleValues = this.selectedType === 'Variable' && 
-      Object.entries(getAllPossibleValuesForVariable(this.variables[this.selectedKey])).map((possibleValue) => {
-        const variationName = possibleValue[0]
-        return `<div class="detail-entry">
-          <span>${variationName}</span>
-          <span class="details-value">${possibleValue[1]}</span>
-        </div>`
-      }) || []
-    const variableKeysInFeature = this.selectedType === 'Feature' && this.features[this.selectedKey]?.variables?.map((variable) => (
-      `
-      <div class="detail-entry">
-        <span>${variable.key}</span>
-      </div>`
-    )) || []
-
-    const projectId = StateManager.getFolderState(folder.name, KEYS.PROJECT_ID)
-    const orgId = getOrganizationId(folder)
-    const dashboardPath = this.selectedType === 'Variable' ? 
-    `variables/${this.variables[this.selectedKey]?.key}` : 
-    `features/${this.features[this.selectedKey]?.key}`
-    const usagesCommand = `command:${OPEN_USAGES_VIEW}?${encodeURIComponent(JSON.stringify({ variableKey: this.selectedKey }))}`
 
     return `
         <div class="inspector-container">
+          ${this.getSelectedFolderContainerHTML(this.selectedFolder)}
           <div class="inspector-dropdown-container">
             <img src="${this._view?.webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'inspector.svg'))}">
-            <vscode-dropdown id="typeId" class="inspector-dropdown-type" data-folder="${folder.index}" data-type="variableOrFeature">
+            <vscode-dropdown id="typeId" class="inspector-dropdown-type" data-type="variableOrFeature">
               ${inspectorOptions.join('')}
             </vscode-dropdown>
-            <vscode-dropdown id="dataId" class="inspector-dropdown-value" data-folder="${folder.index}" data-type="key">
+            <vscode-dropdown id="dataId" class="inspector-dropdown-value" data-type="key">
               ${this.selectedType === 'Variable' ? variableOptions.join('') : featureOptions.join('')}
             </vscode-dropdown>
           </div>
@@ -156,68 +159,35 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
             <i class="codicon codicon-info"></i>
             Details
           </label>
-          <div class="collapsible-content">
-            <div class="details-container">
-              <div class="detail-entry">
-                <span>Name</span>
-                <span class="details-value">${name || '(No Name)'}</span>
-              </div>
-              <div class="detail-entry">
-                <span>Key</span>
-                <span class="details-value">${key}</span>
-              </div>
-              ${featureName ?
-                `<div class="detail-entry">
-                  <span>Feature</span>
-                  <span class="details-value">${featureName}</span>
-                </div>` :
-                ''
-              }
-              <div class="detail-entry">
-              ${this.selectedType === 'Variable' && !!this.matches[this.selectedKey] ? 
-              `
-                <a href="${vscode.Uri.parse(usagesCommand)}" class="detail-link-row">
-                  <i class="codicon codicon-symbol-keyword"></i>
-                  View Usages
-                </a>
-              ` : ''}
-              </div>
-              <div class="detail-entry">
-                <a href="https://app.devcycle.com/o/${orgId}/p/${projectId}/${dashboardPath}" class="detail-link-row">
-                  <i class="codicon codicon-globe"></i>
-                  View in Dashboard
-                </a>
+          ${this.getDetailsHTML(this.selectedFolder)}
+          ${this.selectedType === 'Variable' && possibleValues.length ? `
+            <input id="collapsible-possible=values" class="toggle" type="checkbox" checked>
+            <label for="collapsible-possible=values" class="lbl-toggle">
+              <i class="codicon codicon-chevron-right"></i>
+              <i class="codicon codicon-preserve-case"></i>
+              Possible Values
+            </label>
+            <div class="collapsible-content">
+              <div class="details-container">
+                ${possibleValues.join('')}
               </div>
             </div>
-          </div>
-          ${this.selectedType === 'Variable' ? 
-          `
-          <input id="collapsible-possible=values" class="toggle" type="checkbox" checked>
-          <label for="collapsible-possible=values" class="lbl-toggle">
-            <i class="codicon codicon-chevron-right"></i>
-            <i class="codicon codicon-preserve-case"></i>
-            Possible Values
-          </label>
-          <div class="collapsible-content">
-            <div class="details-container">
-              ${possibleValues.join('')}
+            ` : ''
+          }
+          ${this.selectedType === 'Feature' ? `
+            <input id="collapsible-possible=values" class="toggle" type="checkbox" checked>
+            <label for="collapsible-possible=values" class="lbl-toggle">
+              <i class="codicon codicon-chevron-right"></i>
+              <i class="codicon codicon-preserve-case"></i>
+              Variables
+            </label>
+            <div class="collapsible-content">
+              <div class="details-container">
+                ${variableKeysInFeature.join('')}
+              </div>
             </div>
-          </div>
-          ` : ''}
-          ${this.selectedType === 'Feature' ? 
-          `
-          <input id="collapsible-possible=values" class="toggle" type="checkbox" checked>
-          <label for="collapsible-possible=values" class="lbl-toggle">
-            <i class="codicon codicon-chevron-right"></i>
-            <i class="codicon codicon-preserve-case"></i>
-            Variables
-          </label>
-          <div class="collapsible-content">
-            <div class="details-container">
-              ${variableKeysInFeature.join('')}
-            </div>
-          </div>
-          ` : ''}
+            ` : ''
+          }
         </div>
     `
   }
@@ -236,11 +206,6 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
     )
 
     const nonce = getNonce()
-    const folder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]
-    let body = ''
-    if (folder) {
-      body = await this.getBodyHtml(folder)
-    }
     return `<!DOCTYPE html>
       <html lang="en">
         <head>
@@ -258,10 +223,126 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
         </head>
         <body>
           <main>
-            ${body}
+            ${await this.getBodyHtml()}
           </main>
           <script type="module" nonce="${nonce}" src="${webViewUri}"></script>
         </body>
       </html>`
+  }
+
+  private getSelectedFolderContainerHTML(folder: vscode.WorkspaceFolder) {
+    const folders = vscode.workspace.workspaceFolders
+    if (!folders || folders.length === 1) {
+      return ''
+    }
+    const folderOptions = folders.map((workspaceFolder) => (
+      `<vscode-option value="${workspaceFolder.index}"${workspaceFolder.index === folder.index ? ' selected' : '' }>${workspaceFolder.name}</vscode-option>`
+    ))
+    return `
+      <div class="multiple-folder-container">
+        <i class="codicon codicon-debug-breakpoint-log"></i>
+        <span>${folder.name}</span>
+        <vscode-dropdown id="folderId" class="inspector-dropdown-folder" data-type="folder">
+          ${folderOptions.join('')}
+        </vscode-dropdown>
+      </div>
+    `
+  }
+
+  private getDetailsHTML(folder: vscode.WorkspaceFolder) {
+    const name = this.selectedType === 'Variable' ? 
+      this.variables[this.selectedKey]?.name : 
+      this.features[this.selectedKey]?.name
+    const key = this.selectedType === 'Variable' ? 
+      this.variables[this.selectedKey]?.key : 
+      this.features[this.selectedKey]?.key
+    const featureName = this.selectedType === 'Variable' &&
+      Object.values(this.features).find((feature) => feature._id === (this.variables[this.selectedKey] as Variable)?._feature)?.name
+
+    const projectId = StateManager.getFolderState(folder.name, KEYS.PROJECT_ID)
+    const orgId = getOrganizationId(folder)
+    const dashboardPath = this.selectedType === 'Variable' ? 
+      `variables/${this.variables[this.selectedKey].key}` : 
+      `features/${this.features[this.selectedKey].key}`
+    const usagesCommandParams = encodeURIComponent(
+      JSON.stringify({ 
+        variableKey: this.selectedKey,
+        folderUri: folder.uri
+      })
+    )
+    const usagesCommand = `command:${OPEN_USAGES_VIEW}?${usagesCommandParams}`
+    return `
+      <div class="collapsible-content">
+        <div class="details-container">
+          <div class="detail-entry">
+            <span>Name</span>
+            <span class="details-value">${name || '(No Name)'}</span>
+          </div>
+          <div class="detail-entry">
+            <span>Key</span>
+            <span class="details-value">${key}</span>
+          </div>
+          ${featureName ?
+            `<div class="detail-entry">
+              <span>Feature</span>
+              <span class="details-value">${featureName}</span>
+            </div>` :
+            ''
+          }
+          
+          ${this.selectedType === 'Variable' && this.matches[this.selectedKey] ? `
+            <div class="detail-entry">
+              <a href="${vscode.Uri.parse(usagesCommand)}" class="detail-link-row">
+                <i class="codicon codicon-symbol-keyword"></i>
+                View Usages
+              </a>
+            </div>` : ''
+          }
+          <div class="detail-entry">
+            <a href="https://app.devcycle.com/o/${orgId}/p/${projectId}/${dashboardPath}" class="detail-link-row">
+              <i class="codicon codicon-globe"></i>
+              View in Dashboard
+            </a>
+          </div>
+        </div>
+      </div>`
+  }
+
+  private getPossibleValuesHTML() {
+    const getAllPossibleValuesForVariable = (variable?: Variable) => {
+      const variableVariationValueMap: Record<string, unknown> = {}
+      if (!variable) {
+        return {}
+      }
+     
+      const feature = this.features[variable._feature]
+      if (!feature) {
+        return {}
+      }
+
+      for (const variation of feature.variations || []) {
+        variableVariationValueMap[variation.name] = variation.variables?.[variable.key]
+      }
+      return variableVariationValueMap
+    }
+
+    return this.selectedType === 'Variable' && 
+      Object.entries(getAllPossibleValuesForVariable(this.variables[this.selectedKey])).map((possibleValue) => {
+        const variationName = possibleValue[0]
+        return `<div class="detail-entry">
+          <span>${variationName}</span>
+          <span class="details-value">${possibleValue[1]}</span>
+        </div>`
+      }) || []
+  }
+
+  private getVariableKeysInFeatureHTML() {
+    return this.selectedType === 'Feature' && this.features[this.selectedKey].variables?.map((variable) => (
+      `
+      <div class="detail-entry">
+        <span>${variable.key}</span>
+      </div>`
+    )) || []
+
   }
 }

--- a/src/webview/inspectorView.ts
+++ b/src/webview/inspectorView.ts
@@ -7,17 +7,22 @@ const vscode = acquireVsCodeApi();
 window.addEventListener("load", main);
 
 function main() {
+  const addDropdownValueChangeListenersToDropdowns = (dropdowns: string[]) => {
+    for (const dropdown of dropdowns) {
+      const dropdownElements = document.getElementsByClassName(dropdown) as HTMLCollectionOf<Dropdown>
+      for (let i = 0; i < dropdownElements.length; i++) {
+        const dropdownElement = dropdownElements[i];
+        dropdownElement.addEventListener('change', handleDropdownValueChange)
+      }
+    }
+  }
   // Inspector dropdowns
-  const inspectorDropdownType = document.getElementsByClassName("inspector-dropdown-type") as HTMLCollectionOf<Dropdown>
-  const inspectorDropdownValue = document.getElementsByClassName("inspector-dropdown-value") as HTMLCollectionOf<Dropdown>  
-  for (let i = 0; i < inspectorDropdownType.length; i++) {
-    const dropdown = inspectorDropdownType[i];
-    dropdown.addEventListener('change', handleDropdownValueChange);
-  }
-  for (let i = 0; i < inspectorDropdownValue.length; i++) {
-    const dropdown = inspectorDropdownValue[i];
-    dropdown.addEventListener('change', handleDropdownValueChange);
-  }
+  addDropdownValueChangeListenersToDropdowns([
+    'inspector-dropdown-folder',
+    'inspector-dropdown-type',
+    'inspector-dropdown-value'
+  ])
+
  }
 
 function handleDropdownValueChange(event: Event) {


### PR DESCRIPTION
# Changes

- Added new section when workspace has more than one folder in inspector to show dropdown and selected folder
- only show `View Usages` button when selected folder has the usage for the variable selected
- Added optional param in `OpenUsagesCommand` to pass in a specific folder uri instead of the current open file's folder