### PR TITLE
fix selectedType resetting to Variable after changing feature key in dropdown

### DIFF
--- a/src/commands/openInspectorView/registerOpenInspectorViewCommand.ts
+++ b/src/commands/openInspectorView/registerOpenInspectorViewCommand.ts
@@ -19,7 +19,7 @@ export async function registerOpenInspectorViewCommand(
                     }
 
                     await vscode.commands.executeCommand('devcycle-inspector.focus')
-                    inspectorViewProvider.postMessageToWebview({buttonType, type: 'key', value: variableKey})
+                    inspectorViewProvider.postMessageToWebview({buttonType, type: 'key', value: variableKey, selectedType: 'Variable'})
                 } catch (error) {
                     console.error("Failed to open inspector view: ", error)
                 }

--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -7,7 +7,7 @@ import { INSPECTOR_VIEW_BUTTONS } from '../../components/hoverCard'
 
 type InspectorViewMessage =
   | { type: 'variableOrFeature', value: 'Variable' | 'Feature' }
-  | { type: 'key', value: string, buttonType?: INSPECTOR_VIEW_BUTTONS }
+  | { type: 'key', value: string, buttonType?: INSPECTOR_VIEW_BUTTONS, selectedType?: 'Variable' }
   | { type: 'folder', value: number }
   | { type: 'command', value: 'removeClass' }
 
@@ -90,7 +90,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
           this.selectedKey = features[0] || ''
         }
       } else if (data.type === 'key') {
-        this.selectedType = "Variable"
+        this.selectedType = data?.selectedType || this.selectedType
         this.selectedKey = data.value
         this.buttonType = data?.buttonType
       } else if (data.type === 'folder') {


### PR DESCRIPTION
The `selectedType` was being set to `Variable` every time the key was being changed in the right dropdown. This was resulting in changing feature keys breaking. The `selectedType` shouldnt need to be set at all in that case since it gets updated when the left dropdown is used as well as when the inspector is first instantiated