### PR TITLE
fix: open folder button not working in prod

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,9 +13,6 @@
       "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}",
       "sourceMaps": true,
-      "env": {
-        "DEBUG_MODE": "1"
-      }
     },
     {
       "name": "Extension Tests",

--- a/src/views/startup/StartupViewProvider.ts
+++ b/src/views/startup/StartupViewProvider.ts
@@ -36,14 +36,6 @@ export class StartupViewProvider implements vscode.WebviewViewProvider {
     this._view = panel
   }
 
-  private getScriptUri(webview: vscode.Webview): vscode.Uri {
-    const isDebug = process.env.DEBUG_MODE === '1'
-    const script = `startup.${isDebug ? 'ts' : 'js'}`
-    return webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, isDebug ? 'src' : 'out', `scripts/${script}`),
-    )
-  }
-
   private getBodyHtml(
     view: STARTUP_VIEWS,
   ): string {
@@ -71,8 +63,10 @@ export class StartupViewProvider implements vscode.WebviewViewProvider {
       vscode.Uri.joinPath(this._extensionUri, 'media', 'styles', 'vscode.css'),
     )
 
-    const scriptUri = this.getScriptUri(webview)
-
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, 'out', 'startup.js'),
+    )
+    
     const nonce = getNonce()
 
     return `<!DOCTYPE html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,8 @@ const webviewConfig = {
   target: ["web", "es2020"],
   entry: {
     homeView: "./src/webview/homeView.ts",
-    inspectorView: "./src/webview/inspectorView.ts"
+    inspectorView: "./src/webview/inspectorView.ts",
+    startup: "./src/scripts/startup.ts",
   },
   experiments: { outputModule: true },
   output: {


### PR DESCRIPTION
- remove unused env variable
- include startup script in webpack config