### PR TITLE
chore: skip integration tests on workflow

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Unit Tests
         run: yarn test
 
-      - name: Integration Tests
-        run: yarn test:integration
+      # - name: Integration Tests
+      #   run: yarn test:integration


### PR DESCRIPTION
- skip integration tests for now as they're not ready yet