### PR TITLE
fix: don't evaluate getFeatureEnvironmentStatusesHTML for variables

### DIFF
--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -384,6 +384,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async getFeatureEnvironmentStatusesHTML(folder: vscode.WorkspaceFolder) {
+    if (this.selectedType !== 'Feature') return ''
 
     function isRecordOfStringEnvironment(obj: any): obj is Record<string, Environment> {
       return typeof obj === 'object' && obj !== null && Object.keys(obj).length > 0


### PR DESCRIPTION
Currently `getFeatureEnvironmentStatusesHTML` is being called for variables which results in 404 errors being shown each time the inspector re-renders