### PR TITLE
chore: add indent indicators to the inspector view

### DIFF
--- a/media/styles/homeView.css
+++ b/media/styles/homeView.css
@@ -3,10 +3,6 @@ body {
   background-color: unset;
 }
 
-#home-view-main:hover .collaspsible-content-indent {
-  border-left: 1px solid var(--vscode-tree-inactiveIndentGuidesStroke);
-}
-
 #home-nav {
   display: flex;
   justify-content: space-between;
@@ -67,22 +63,10 @@ input[type='checkbox'] {
 }
 
 .collapsible-content {
-  display: flex;
   max-height: 0px;
   overflow: hidden;
   padding-left: 1.2rem;
   position: relative;
-}
-
-.collaspsible-content-indent {
-  height: 100%;
-  position: absolute;
-  left: 6px;
-  width: 0;
-  border: none;
-  box-sizing: border-box;
-  border-color: transparent;
-  transition: border-color .1s linear;
 }
 
 .home-view-form-container {
@@ -103,20 +87,6 @@ input[type='checkbox'] {
   gap: 6px;
   color: var(--vscode-foreground);
   font-size: var(--vscode-font-size);
-}
-
-.toggle:checked + .lbl-toggle + .collapsible-content {
-  max-height: fit-content;
-  overflow: visible;
-}
-
-.toggle:checked + .lbl-toggle > i {
-  transform: rotate(90deg)
-}
-
-.toggle:checked + .lbl-toggle {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
 }
 
 .edit-config-button {

--- a/media/styles/inspector.css
+++ b/media/styles/inspector.css
@@ -11,26 +11,6 @@ input[type='checkbox'] {
   padding-top: 0.4rem;
 }
 
-.collapsible-content {
-  max-height: 0px;
-  overflow: hidden;
-  padding-left: 1.2rem;
-}
-
-.toggle:checked + .lbl-toggle + .collapsible-content {
-  max-height: fit-content;
-  overflow: visible;
-}
-
-.toggle:checked + .lbl-toggle > .codicon-chevron-right {
-  transform: rotate(90deg)
-}
-
-.toggle:checked + .lbl-toggle {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-
 .inspector-container {
   display: flex;
   flex-direction: column;
@@ -46,23 +26,16 @@ input[type='checkbox'] {
   display: flex;
   justify-content: left;
   align-items: center;
+  gap: 5px;
 }
 
 .multiple-folder-container i, label {
-  margin-right: 0.5rem;
-  color: var(--vscode-foreground);
+   color: var(--vscode-foreground);
 }
 
 .inspector-dropdown-folder {
   width: auto;
   flex-grow: 1;
-}
-
-.inspector-dropdown-container {
-  margin-top: 0.3rem;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
 }
 
 .inspector-dropdown-container img {
@@ -74,11 +47,6 @@ input[type='checkbox'] {
   font-size: var(--vscode-font-size);
 }
 
-.inspector-dropdown-type {
-  margin-right: 0.3rem;
-  width: fit-content;
-}
-
 .inspector-dropdown-value {
   width: -webkit-fill-available;
 }
@@ -87,6 +55,16 @@ input[type='checkbox'] {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+}
+
+.inspector-header {
+  display: grid;
+  grid-template-columns: min-content min-content 1fr;
+  row-gap: 5px;
+  column-gap: 5px;
+  width: 100%;
+  justify-self: center;
+  align-items: center;
 }
 
 .details-container > * {
@@ -102,6 +80,8 @@ input[type='checkbox'] {
 
 .detail-entry-value-link {
   display: flex;
+  align-items: center;
+  gap: 5px;
 }
 
 .detail-entry-value-link > * {

--- a/media/styles/vscode.css
+++ b/media/styles/vscode.css
@@ -139,3 +139,39 @@ textarea::placeholder {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+.collapsible-content {
+  max-height: 0px;
+  overflow: hidden;
+  padding-left: 1.2rem;
+  position: relative;
+}
+
+.collaspsible-content-indent {
+  height: 100%;
+  position: absolute;
+  left: 6px;
+  width: 0;
+  border: none;
+  box-sizing: border-box;
+  border-color: transparent;
+  transition: border-color .1s linear;
+}
+
+main:hover .collaspsible-content-indent {
+  border-left: 1px solid var(--vscode-tree-inactiveIndentGuidesStroke);
+}
+
+.toggle:checked + .lbl-toggle + .collapsible-content {
+  max-height: fit-content;
+  overflow: visible;
+}
+
+.toggle:checked + .lbl-toggle {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.toggle:checked + .lbl-toggle > .codicon-chevron-right {
+  transform: rotate(90deg)
+}

--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -170,8 +170,8 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
     
     return `
         <div class="inspector-container">
-          ${this.getSelectedFolderContainerHTML(this.selectedFolder)}
-          <div class="inspector-dropdown-container">
+          <div class="inspector-header">
+            ${this.getSelectedFolderContainerHTML(this.selectedFolder)}
             <div class="inspector-svg-container">${this.inspectorSvg()}</div>
             <vscode-dropdown id="typeId" class="inspector-dropdown-type" data-type="variableOrFeature">
               ${inspectorOptions.join('')}
@@ -195,6 +195,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
               Possible Values
             </label>
             <div class="collapsible-content">
+              <div class="collaspsible-content-indent"></div>
               <div class="details-container">
                 ${possibleValues.join('')}
               </div>
@@ -209,6 +210,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
               Variables
             </label>
             <div class="collapsible-content">
+              <div class="collaspsible-content-indent"></div>
               <div class="details-container">
                 ${variableKeysInFeature.join('')}
               </div>
@@ -271,13 +273,11 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
       `<vscode-option value="${workspaceFolder.index}"${workspaceFolder.index === folder.index ? ' selected' : '' }>${workspaceFolder.name}</vscode-option>`
     ))
     return `
-      <div class="multiple-folder-container">
-        <i class="codicon codicon-debug-breakpoint-log"></i>
-        <label>${folder.name}</label>
-        <vscode-dropdown id="folderId" class="inspector-dropdown-folder" data-type="folder">
-          ${folderOptions.join('')}
-        </vscode-dropdown>
-      </div>
+      <i class="codicon codicon-debug-breakpoint-log"></i>
+      <label>${folder.name}</label>
+      <vscode-dropdown id="folderId" class="inspector-dropdown-folder" data-type="folder">
+        ${folderOptions.join('')}
+      </vscode-dropdown>
     `
   }
 
@@ -305,6 +305,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
     const usagesCommand = `command:${OPEN_USAGES_VIEW}?${usagesCommandParams}`
     return `
       <div class="collapsible-content">
+        <div class="collaspsible-content-indent"></div>
         <div class="details-container">
           <div class="detail-entry">
             <label>Name</label>
@@ -414,6 +415,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
       Status
     </label>
     <div class="collapsible-content">
+      <div class="collaspsible-content-indent"></div>
       <div class="details-container">
         ${html.join('')}
       </div>


### PR DESCRIPTION
# Changes
* Add indent indicators to the Inspector View
* De-dup styles that were in both `inspector.css` and `homeView.css`
* Align the look of inspector folder selector to the figma mock up

<img width="378" alt="image" src="https://github.com/DevCycleHQ/vscode-extension/assets/33500361/8462b3f9-71c7-4380-9b7b-1bafb647aed4">

<img width="375" alt="image" src="https://github.com/DevCycleHQ/vscode-extension/assets/33500361/a5db0247-c57a-45c3-861d-8ea7f768a1f9">

