### PR TITLE
replace open in dashboard option with an inspector link in usages

### DIFF
--- a/media/inspector-white.svg
+++ b/media/inspector-white.svg
@@ -1,0 +1,8 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 10.052C6 7.81416 7.81416 6 10.052 6C12.2899 6 14.1041 7.81416 14.1041 10.052C14.1041 10.995 13.7818 11.8631 13.2415 12.5516L16.8571 16.1672C17.0476 16.3577 17.0476 16.6666 16.8571 16.8571C16.6666 17.0476 16.3577 17.0476 16.1672 16.8571L12.5516 13.2415C11.8631 13.7818 10.995 14.1041 10.052 14.1041C7.81416 14.1041 6 12.2899 6 10.052ZM10.052 6.97563C8.35299 6.97563 6.97563 8.35299 6.97563 10.052C6.97563 11.7511 8.35299 13.1284 10.052 13.1284C11.7511 13.1284 13.1284 11.7511 13.1284 10.052C13.1284 8.35299 11.7511 6.97563 10.052 6.97563Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13 1.75H1V1H13V1.75Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 3.75H1V3H10V3.75Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6.25 5.75H1V5H6.25V5.75Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 7.75H1V7H4V7.75Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.5 9.75H1V9H2.5V9.75Z" fill="#C5C5C5"/>
+</svg>

--- a/src/components/hoverCard.ts
+++ b/src/components/hoverCard.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode'
 import { CombinedVariableData, getCombinedVariableDetails } from '../cli'
 import { KEYS, StateManager } from '../StateManager'
+import { OPEN_INSPECTOR_VIEW, OPEN_USAGES_VIEW } from '../commands'
 
-const openInspectorViewCommand = 'command:devcycle-feature-flags.openInspectorView'
-const usagesCommand = 'command:devcycle-feature-flags.openUsagesView'
+const openInspectorViewCommand = `command:${OPEN_INSPECTOR_VIEW}`
+const usagesCommand = `command:${OPEN_USAGES_VIEW}`
 
 export enum INSPECTOR_VIEW_BUTTONS {
   POSSIBLE_VALUES = 'values',

--- a/src/views/usages/UsagesTree/CodeUsageNode.ts
+++ b/src/views/usages/UsagesTree/CodeUsageNode.ts
@@ -8,7 +8,7 @@ import {
 import path from 'path'
 
 import { KEYS, StateManager } from '../../../StateManager'
-import { COMMAND_OPEN_LINK } from '../../../commands'
+import { OPEN_INSPECTOR_VIEW } from '../../../commands'
 
 export type VariableCodeReference = JSONMatch & { variable?: Variable }
 
@@ -64,19 +64,29 @@ export class CodeUsageNode extends vscode.TreeItem {
       const orgId = getOrganizationId(folder)
       const projectId = StateManager.getFolderState(folder.name, KEYS.PROJECT_ID)
       if (orgId && projectId) {
-        const link = `https://app.devcycle.com/o/${orgId}/p/${projectId}/variables/${variable._id}`
         const linkNode = new CodeUsageNode(
           key + ':link',
-          `Open In Dashboard ↗`,
+          `Inspector`,
           'detail',
           [],
         )
         linkNode.command = {
           title: '',
-          command: COMMAND_OPEN_LINK,
-          arguments: [link],
+          command: OPEN_INSPECTOR_VIEW,
+          arguments: [{ buttonType: 'details', variableKey: variable.key }],
         }
-        linkNode.tooltip = link
+        linkNode.iconPath = {
+          dark: vscode.Uri.joinPath(
+            context.extensionUri,
+            'media',
+            'inspector-white.svg',
+          ),
+          light: vscode.Uri.joinPath(
+            context.extensionUri,
+            'media',
+            'inspector.svg',
+          ),
+        }
         detailsChildNodes.push(linkNode)
       }
 

--- a/src/views/usages/UsagesTree/UsagesTreeProvider.ts
+++ b/src/views/usages/UsagesTree/UsagesTreeProvider.ts
@@ -8,7 +8,6 @@ import {
 
 import { CodeUsageNode } from './CodeUsageNode'
 import { FolderNode } from '../../utils/tree/FolderNode'
-import { KEYS, StateManager } from '../../../StateManager'
 
 export class UsagesTreeProvider
   implements vscode.TreeDataProvider<CodeUsageNode>


### PR DESCRIPTION
Note: I think it would also be good to get rid of the details section from the usages tree, but that will break sorting. Gonna see if theres a way I can keep sorting working as is and just hide the details section so I don't need to completely redo how sorting usages works.

![image](https://github.com/DevCycleHQ/vscode-extension/assets/17012546/9308e372-504c-4213-8995-bc8e2d39f9b7)
