### PR TITLE
chore: remove and update event listeners for removing focus style

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,11 +147,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
     await executeRefreshAllCommand()
   })
 
-  const disposable = vscode.window.onDidChangeTextEditorSelection(() => {
-    inspectorViewProvider?.postMessageToWebview({ type: 'command', value: 'removeClass' })
-  })
-  
-  context.subscriptions.push(disposable)
 }
 
 export function deactivate() {}

--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -9,7 +9,6 @@ type InspectorViewMessage =
   | { type: 'variableOrFeature', value: 'Variable' | 'Feature' }
   | { type: 'key', value: string, buttonType?: INSPECTOR_VIEW_BUTTONS, selectedType?: 'Variable' | 'Feature' }
   | { type: 'folder', value: number }
-  | { type: 'command', value: 'removeClass' }
 
 
 const selectAProjectHtml = `<!DOCTYPE html>
@@ -96,11 +95,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
       } else if (data.type === 'folder') {
         this.selectedFolder = vscode.workspace.workspaceFolders?.[data.value] as vscode.WorkspaceFolder
         this.matches = StateManager.getFolderState(this.selectedFolder.name, KEYS.CODE_USAGE_KEYS) || {}
-      } else if (data.type === 'command') {
-        if (data.value === 'removeClass') {
-          this.buttonType = undefined
-        }
-      }
+      } 
       webviewView.webview.html = await this._getHtmlForWebview(webviewView.webview)
     })
   }

--- a/src/webview/inspectorView.ts
+++ b/src/webview/inspectorView.ts
@@ -6,13 +6,16 @@ const vscode = acquireVsCodeApi();
 
 window.addEventListener("load", main);
 
-window.addEventListener('click', (event) => {
-  const clickedElement = event.target
-  // Check if the clicked element is not inside the webview
-  if (!document.body.contains(clickedElement as Node)) {
-    vscode.postMessage({ type:'command', value: 'removeClass' });
-  }
-});
+const focusedElement = document.querySelector('.focus')
+
+if (focusedElement) {
+  focusedElement.scrollIntoView()
+
+  window.addEventListener('click', () => {
+    focusedElement.classList.remove('focus')
+  }, { once: true })
+}
+
 
 window.addEventListener('message', (event) => {
   const message = event.data


### PR DESCRIPTION
the previous event listeners for removing the focus style in the inspector view are too noisy
- remove the event listener from the editor
- remove the event listener in the inspector view when the focus style is cleared
- update the focus flow with `scrollIntoView()` to make sure the target get focused even in a shorter view