### PR TITLE
fix: project not set when two folders opened

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
   const settingsConfig = vscode.workspace.getConfiguration('devcycle-feature-flags')
   
   if (settingsConfig.get('loginOnWorkspaceOpen')) {
-    utils.loginAndRefresh()
+    await utils.loginAndRefresh()
   }
 
   // On Hover


### PR DESCRIPTION
- didn't await `loginAndRefresh()` so `activeProjectKey` was undefined and resulting unselected project when two folders are opened