### PR TITLE
feat: Don't require all folders to be logged in

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -3,6 +3,7 @@ import { Environment, Feature, FeatureConfiguration, Organization, Project, Vari
 import { RepoConfig } from './utils/loadRepoConfig'
 
 export const enum KEYS {
+  LOGGED_IN = 'logged_in',
   REPO_CONFIG = 'repo_config',
   PROJECT_ID = 'project_id',
   PROJECTS = 'projects',
@@ -25,10 +26,11 @@ export class StateManager {
   static clearState() {
     this.workspaceState.keys().forEach((key) => {
       if (
-          !(key.includes(KEYS.PROJECT_ID)||
-          key.includes(KEYS.ORGANIZATION)||
-          key.includes(KEYS.AUTH0_USER_ID))
-        ) {
+        !key.includes(KEYS.PROJECT_ID) &&
+        !key.includes(KEYS.ORGANIZATION) &&
+        !key.includes(KEYS.AUTH0_USER_ID) &&
+        !key.includes(KEYS.LOGGED_IN)
+      ) {
         this.workspaceState.update(key, undefined)
       }
     })
@@ -36,11 +38,13 @@ export class StateManager {
 
   static clearFolderState(folder: string) {
     this.workspaceState.keys().forEach((key) => {
-      if (key.startsWith(`${folder}.`) && !(
-        key.includes(KEYS.PROJECT_ID)||
-        key.includes(KEYS.ORGANIZATION)||
-        key.includes(KEYS.AUTH0_USER_ID))
-        ) {
+      if (
+        key.startsWith(`${folder}.`) &&
+        !key.includes(KEYS.PROJECT_ID) &&
+        !key.includes(KEYS.ORGANIZATION) &&
+        !key.includes(KEYS.AUTH0_USER_ID) &&
+        !key.includes(KEYS.LOGGED_IN)
+      ) {
         this.workspaceState.update(key, undefined)
       }
     })
@@ -70,6 +74,7 @@ export class StateManager {
     return this.workspaceState.get(key)
   }
 
+  static setFolderState(folder: string, key: KEYS.LOGGED_IN, value: boolean): Thenable<void>
   static setFolderState(folder: string, key: KEYS.REPO_CONFIG, value: RepoConfig): Thenable<void>
   static setFolderState(folder: string, key: KEYS.PROJECT_ID, value: string | undefined): Thenable<void>
   static setFolderState(folder: string, key: KEYS.PROJECTS, value: Record<string, Project> | undefined): Thenable<void>
@@ -83,6 +88,7 @@ export class StateManager {
     return this.workspaceState.update(`${folder}.${key}`, value)
   }
 
+  static getFolderState(folder: string, key: KEYS.LOGGED_IN): boolean | undefined
   static getFolderState(folder: string, key: KEYS.REPO_CONFIG): RepoConfig | undefined
   static getFolderState(folder: string, key: KEYS.PROJECT_ID): string | undefined
   static getFolderState(folder: string, key: KEYS.PROJECTS): Record<string, Project> | undefined

--- a/src/cli/AuthCLIController.ts
+++ b/src/cli/AuthCLIController.ts
@@ -51,7 +51,9 @@ export class AuthCLIController extends BaseCLIController {
       if (!repoConfigExists && initRepoOnLogin && org) {
         await this.init(org)
       }
+      StateManager.setFolderState(this.folder.name, KEYS.LOGGED_IN, true)
     } catch (e) {
+      StateManager.setFolderState(this.folder.name, KEYS.LOGGED_IN, false)
       if (e instanceof Error) {
         utils.showDebugOutput(`Login failed ${e.message}`)
         throw e
@@ -65,6 +67,7 @@ export class AuthCLIController extends BaseCLIController {
     const { code, error } = await this.execDvc('logout')
     if (code === 0) {
       vscode.window.showInformationMessage('Logged out of DevCycle')
+      StateManager.setFolderState(this.folder.name, KEYS.LOGGED_IN, false)
     } else {
       vscode.window.showInformationMessage(`Logout failed ${error?.message}}`)
     }

--- a/src/commands/refreshInspector/registerRefreshInspectorCommand.ts
+++ b/src/commands/refreshInspector/registerRefreshInspectorCommand.ts
@@ -12,14 +12,8 @@ export async function registerRefreshInspectorCommand(
       COMMAND_REFRESH_INSPECTOR,
       async ({ folder }: { folder?: vscode.WorkspaceFolder } = {}) => {
         if (folder) {
-          StateManager.setFolderState(folder.name, KEYS.FEATURES, undefined)
-          StateManager.setFolderState(folder.name, KEYS.VARIABLES, undefined)
           await inspectorViewProvider.refresh(folder)
         } else {
-          vscode.workspace.workspaceFolders?.forEach(({ name }) => {
-            StateManager.setFolderState(name, KEYS.FEATURES, undefined)
-            StateManager.setFolderState(name, KEYS.VARIABLES, undefined)
-          })
           await inspectorViewProvider.refreshAll()
         }
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import cliUtils from './cli/utils'
 import utils from './utils'
 import { InspectorViewProvider, registerInspectorViewProvider } from './views/inspector'
 import { loadRepoConfig } from './utils/loadRepoConfig'
+import { loginAndRefresh } from './utils/loginAndRefresh'
 
 Object.defineProperty(exports, '__esModule', { value: true })
 exports.deactivate = exports.activate = void 0
@@ -72,7 +73,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
   const environmentsDataProvider = await registerEnvironmentsViewProvider(context)
   const inspectorViewProvider = await registerInspectorViewProvider(context)
   const refreshProviders: (UsagesTreeProvider | EnvironmentsTreeProvider | InspectorViewProvider)[] = [
-    usagesDataProvider, 
+    usagesDataProvider,
     environmentsDataProvider,
     inspectorViewProvider
   ]
@@ -97,7 +98,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
   const settingsConfig = vscode.workspace.getConfiguration('devcycle-feature-flags')
   
   if (settingsConfig.get('loginOnWorkspaceOpen')) {
-    await utils.loginAndRefresh()
+    await utils.loginAndRefreshAll()
   }
 
   // On Hover
@@ -140,11 +141,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
   vscode.workspace.onDidChangeWorkspaceFolders(async (event) => {
     utils.checkForWorkspaceFolders()
-    for (const folder of event.added) {
-      const cli = new AuthCLIController(folder)
-      await cli.login()
-    }
-    await executeRefreshAllCommand()
+    await loginAndRefresh([...event.added])
   })
 
 }

--- a/src/utils/loginAndRefresh.test.ts
+++ b/src/utils/loginAndRefresh.test.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode'
 import { describe, it, afterEach } from 'mocha'
 import sinon from 'sinon'
 import { AuthCLIController } from '../cli'
-import { loginAndRefresh } from './loginAndRefresh'
+import { loginAndRefreshAll } from './loginAndRefresh'
 import { COMMAND_REFRESH_ALL } from '../commands'
 
-describe('loginAndRefresh', () => {
+describe('loginAndRefreshAll', () => {
   const folder = { name: 'test-folder', uri: vscode.Uri.parse('file:///test-folder'), index: 0 }
   const folder2 = { name: 'test-folder2', uri: vscode.Uri.parse('file:///test-folder2'), index: 1 }
 
@@ -18,19 +18,20 @@ describe('loginAndRefresh', () => {
     sinon.stub(vscode.commands, 'executeCommand')
     const mockLogin = sinon.stub(AuthCLIController.prototype, 'login').resolves()
 
-    await loginAndRefresh()
+    await loginAndRefreshAll()
 
     sinon.assert.calledTwice(mockLogin)
   })
 
-  it('refreshes all folders', async () => {
+  it('calls refresh for each folder', async () => {
     sinon.stub(vscode.workspace, 'workspaceFolders').value([folder, folder2])
     const mockExecuteCommand = sinon.stub(vscode.commands, 'executeCommand')
     sinon.stub(AuthCLIController.prototype, 'login').resolves()
 
-    await loginAndRefresh()
+    await loginAndRefreshAll()
 
-    sinon.assert.calledWith(mockExecuteCommand, COMMAND_REFRESH_ALL, { folder: undefined })
+    sinon.assert.calledWith(mockExecuteCommand, COMMAND_REFRESH_ALL, { folder })
+    sinon.assert.calledWith(mockExecuteCommand, COMMAND_REFRESH_ALL, { folder: folder2 })
   })
 
   it('sets hasCredentialsAndProject to true', async () => {
@@ -38,7 +39,7 @@ describe('loginAndRefresh', () => {
     const mockExecuteCommand = sinon.stub(vscode.commands, 'executeCommand')
     sinon.stub(AuthCLIController.prototype, 'login').resolves()
 
-    await loginAndRefresh()
+    await loginAndRefreshAll()
 
     sinon.assert.calledWith(
       mockExecuteCommand,
@@ -53,7 +54,7 @@ describe('loginAndRefresh', () => {
     const mockExecuteCommand = sinon.stub(vscode.commands, 'executeCommand')
     sinon.stub(AuthCLIController.prototype, 'login').throws(new Error('test error'))
 
-    await loginAndRefresh().catch(() => {})
+    await loginAndRefreshAll().catch(() => {})
 
     sinon.assert.notCalled(mockExecuteCommand)
   })

--- a/src/utils/loginAndRefresh.ts
+++ b/src/utils/loginAndRefresh.ts
@@ -2,17 +2,30 @@ import * as vscode from 'vscode'
 import { AuthCLIController } from '../cli'
 import { executeRefreshAllCommand } from '../commands'
 
-export async function loginAndRefresh() {
-  const folders = vscode.workspace.workspaceFolders || []
-  for (const folder of folders) {
-    const cli = new AuthCLIController(folder)
-    await cli.login()
-  }
-  await executeRefreshAllCommand()
+export async function loginAndRefreshAll() {
+  const { workspaceFolders = [] } = vscode.workspace
+  await loginAndRefresh([...workspaceFolders])
+}
 
-  await vscode.commands.executeCommand(
-    'setContext',
-    'devcycle-feature-flags.hasCredentialsAndProject',
-    true,
+export async function loginAndRefresh(folders: vscode.WorkspaceFolder[]) {
+  const foldersLoggedIn = []
+
+  for (const folder of folders) {
+    try {
+      const cli = new AuthCLIController(folder)
+      await cli.login()
+      foldersLoggedIn.push(folder)
+    } catch (e) {}
+  }
+  await Promise.all(
+    foldersLoggedIn.map(executeRefreshAllCommand)
   )
+
+  if (foldersLoggedIn.length > 0) {
+    await vscode.commands.executeCommand(
+      'setContext',
+      'devcycle-feature-flags.hasCredentialsAndProject',
+      true,
+    )
+  }
 }

--- a/src/views/environments/EnvironmentsTreeProvider.test.ts
+++ b/src/views/environments/EnvironmentsTreeProvider.test.ts
@@ -6,6 +6,9 @@ import { EnvironmentsTreeProvider } from './EnvironmentsTreeProvider'
 import { Environment, EnvironmentsCLIController } from '../../cli'
 import { EnvironmentNode, KeyListNode, KeyNode, LinkNode } from './nodes'
 import { FolderNode } from '../utils/tree/FolderNode'
+import { StateManager } from '../../StateManager'
+
+const mockGetState = sinon.stub().returns(true)
 
 describe('EnvironmentsTreeProvider', () => {
   const folder = { name: 'test-folder', uri: vscode.Uri.parse('file:///test-folder'), index: 0 }
@@ -33,6 +36,7 @@ describe('EnvironmentsTreeProvider', () => {
     getAllEnvironmentsStub = sinon.stub(EnvironmentsCLIController.prototype, 'getAllEnvironments').resolves({
       'development': environment
     })
+    StateManager.getFolderState = mockGetState
   })
 
   afterEach(() => {

--- a/src/views/environments/EnvironmentsTreeProvider.ts
+++ b/src/views/environments/EnvironmentsTreeProvider.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { FolderNode } from '../utils/tree/FolderNode'
 import { EnvironmentsCLIController } from '../../cli'
 import { EnvironmentNode, KeyListNode } from './nodes'
+import { KEYS, StateManager } from '../../StateManager'
 
 const ENV_ORDER = {
   development: 0,
@@ -31,7 +32,8 @@ export class EnvironmentsTreeProvider
   }
 
   async refresh(folder: vscode.WorkspaceFolder): Promise<void> {
-    if (this.isRefreshing[folder.name]) {
+    const isLoggedIn = StateManager.getFolderState(folder.name, KEYS.LOGGED_IN)
+    if (!isLoggedIn || this.isRefreshing[folder.name]) {
       return
     }
 

--- a/src/views/login/LoginViewProvider.ts
+++ b/src/views/login/LoginViewProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import { getNonce } from '../../utils/getNonce'
-import { loginAndRefresh } from '../../utils/loginAndRefresh'
+import { loginAndRefreshAll } from '../../utils/loginAndRefresh'
 
 const enum ACTIONS {
   LOGIN = 'login',
@@ -31,7 +31,7 @@ export class LoginViewProvider implements vscode.WebviewViewProvider {
 
     webviewView.webview.onDidReceiveMessage(async (data: Data) => {
       try {
-        await loginAndRefresh()
+        await loginAndRefreshAll()
       } catch (e) {
         webviewView.webview.html = this._getHtmlForWebview(
           webviewView.webview,

--- a/src/views/usages/UsagesTree/UsagesTreeProvider.ts
+++ b/src/views/usages/UsagesTree/UsagesTreeProvider.ts
@@ -8,6 +8,7 @@ import {
 
 import { CodeUsageNode } from './CodeUsageNode'
 import { FolderNode } from '../../utils/tree/FolderNode'
+import { KEYS, StateManager } from '../../../StateManager'
 
 export class UsagesTreeProvider
   implements vscode.TreeDataProvider<CodeUsageNode>
@@ -61,7 +62,8 @@ export class UsagesTreeProvider
   }
 
   async refresh(folder: vscode.WorkspaceFolder, showLoading: boolean = true): Promise<void> {
-    if (this.isRefreshing[folder.name]) {
+    const isLoggedIn = StateManager.getFolderState(folder.name, KEYS.LOGGED_IN)
+    if (!isLoggedIn || this.isRefreshing[folder.name]) {
       return
     }
 

--- a/src/webview/homeView.ts
+++ b/src/webview/homeView.ts
@@ -27,6 +27,18 @@ function main() {
     });
   });
 
+  // Login button
+  const loginButtons = document.getElementsByClassName("login-button")
+  for (let i = 0; i < loginButtons.length; i++) {
+    loginButtons[i].addEventListener('click', (event) => {
+      const buttonElement = event.target as HTMLButtonElement
+      vscode.postMessage({
+        type: 'login',
+        folderIndex: buttonElement.dataset.folder
+      });
+    })
+  }
+
   // Home section dropdowns
   const homeSectionDropdowns = document.getElementsByClassName("home-dropdown") as HTMLCollectionOf<Dropdown>;
   for (let i = 0; i < homeSectionDropdowns.length; i++) {
@@ -34,11 +46,11 @@ function main() {
     dropdown.addEventListener('change', handleDropdownValueChange);
   }
 
-  const editConfigButtons = document.getElementsByClassName("edit-config-button") as HTMLCollectionOf<HTMLAnchorElement>;
+  const editConfigButtons = document.getElementsByClassName("edit-config-button")
   for (let i = 0; i < editConfigButtons.length; i++) {
     // Edit config button
-    const editConfigButton = document.getElementById(`editConfigButton${i}`) as HTMLAnchorElement;
-    editConfigButton.addEventListener('click', handleEditConfigClick);
+    const editConfigButton = document.getElementById(`editConfigButton${i}`)
+    editConfigButton?.addEventListener('click', handleEditConfigClick);
   }
 }
 


### PR DESCRIPTION
Currently if one folder in the workspace is not logged in the extension will display the login view. This change allows the user to be logged in some folders but not others (for example, projects that don't use devcycle). If no folders are logged in the existing login view will be displayed.
![Screen Shot 2023-09-11 at 10 03 00 AM](https://github.com/DevCycleHQ/vscode-extension/assets/22960213/e587d53a-5ce2-47bf-a81c-86fb4a2da5f0)

- Track the logged in state of each folder
- Add method to login specific folder
- Display a login button in the home section if a folder is not logged in. All other sections will be empty