### PR TITLE
fix: inspector button not working when no file is open

### DIFF
--- a/src/commands/openInspectorView/registerOpenInspectorViewCommand.ts
+++ b/src/commands/openInspectorView/registerOpenInspectorViewCommand.ts
@@ -9,11 +9,11 @@ export async function registerOpenInspectorViewCommand(
     context.subscriptions.push(
         vscode.commands.registerCommand(
             OPEN_INSPECTOR_VIEW,
-            async ({ buttonType, variableKey }: { buttonType: string, variableKey: string }) => {
+            async ({ buttonType, variableKey, folderUri }: { buttonType: string, variableKey: string, folderUri?: string }) => {
                 try {
-                    const activeDocumentUri = vscode.window.activeTextEditor?.document.uri
+                    const activeDocumentUri = (folderUri && vscode.Uri.parse(folderUri)) || vscode.window.activeTextEditor?.document.uri
                     const currentFolder = activeDocumentUri ? vscode.workspace.getWorkspaceFolder(activeDocumentUri) : undefined
-                
+
                     if (!currentFolder) {
                         return
                     }

--- a/src/views/usages/UsagesTree/CodeUsageNode.ts
+++ b/src/views/usages/UsagesTree/CodeUsageNode.ts
@@ -59,36 +59,6 @@ export class CodeUsageNode extends vscode.TreeItem {
           new CodeUsageNode(key + ':name', `Name`, 'detail', [], variable.name),
         )
       }
-      
-
-      const orgId = getOrganizationId(folder)
-      const projectId = StateManager.getFolderState(folder.name, KEYS.PROJECT_ID)
-      if (orgId && projectId) {
-        const linkNode = new CodeUsageNode(
-          key + ':link',
-          `Inspector`,
-          'detail',
-          [],
-        )
-        linkNode.command = {
-          title: '',
-          command: OPEN_INSPECTOR_VIEW,
-          arguments: [{ buttonType: 'details', variableKey: variable.key }],
-        }
-        linkNode.iconPath = {
-          dark: vscode.Uri.joinPath(
-            context.extensionUri,
-            'media',
-            'inspector-white.svg',
-          ),
-          light: vscode.Uri.joinPath(
-            context.extensionUri,
-            'media',
-            'inspector.svg',
-          ),
-        }
-        detailsChildNodes.push(linkNode)
-      }
 
       const variableDetailsRoot = new CodeUsageNode(
         key,
@@ -97,7 +67,7 @@ export class CodeUsageNode extends vscode.TreeItem {
         detailsChildNodes,
       )
       children.push(variableDetailsRoot)
-    } 
+    }
 
     const usagesChildNodes = references.map((reference) =>
       this.usageFrom(match, reference, folder.uri.fsPath),
@@ -109,6 +79,33 @@ export class CodeUsageNode extends vscode.TreeItem {
       usagesChildNodes,
     )
     children.push(usagesRoot)
+
+    if (variable) {
+      const inspectorLinkNode = new CodeUsageNode(
+        key + ':link',
+        `Inspector`,
+        'detail',
+        [],
+      )
+      inspectorLinkNode.command = {
+        title: '',
+        command: OPEN_INSPECTOR_VIEW,
+        arguments: [{ buttonType: 'details', variableKey: variable.key, folderUri: folder.uri.fsPath }],
+      }
+      inspectorLinkNode.iconPath = {
+        dark: vscode.Uri.joinPath(
+          context.extensionUri,
+          'media',
+          'inspector-white.svg',
+        ),
+        light: vscode.Uri.joinPath(
+          context.extensionUri,
+          'media',
+          'inspector.svg',
+        ),
+      }
+      children.push(inspectorLinkNode)
+    }
 
     const instance = new CodeUsageNode(key, key, 'flag', children)
     instance.key = key


### PR DESCRIPTION
# Changes
* Move inspector button in code usage node outside of details sub tree
* fix bug where inspector button did not work if a user did not have a file open in the current repo

<img width="411" alt="image" src="https://github.com/DevCycleHQ/vscode-extension/assets/33500361/97ba007d-34f4-4713-adcd-58c318992b79">
