### PR TITLE
fix inspector to work properly with multiple folders open in the workspace

### DIFF
--- a/src/views/inspector/InspectorViewProvider.test.ts
+++ b/src/views/inspector/InspectorViewProvider.test.ts
@@ -123,5 +123,14 @@ describe('InspectorViewProvider', () => {
 
       sinon.assert.match(inspectorViewProvider.selectedFolder, undefined)
     })
+
+    it('refreshing should not update the selectedKey or selectedFolder if they are still valid', async () => {
+      const inspectorViewProvider = new InspectorViewProvider(vscode.Uri.parse('extensionUri'))
+      const selectedKey = inspectorViewProvider.selectedKey
+      const selectedFolder = inspectorViewProvider.selectedFolder
+      await inspectorViewProvider.refreshAll()
+      sinon.assert.match(inspectorViewProvider.selectedFolder, selectedFolder)
+      sinon.assert.match(inspectorViewProvider.selectedKey, selectedKey)
+    })
   })
 })


### PR DESCRIPTION
- don't update the selectedKey if the currently selectedKey is still in the variables list. This is so that the selectedKey doesnt randomly change on refresh
- re-initialize features and variables when a new folder is added
- don't update the currently selected folder in the refresh function, that should never have been happening (afaik)