### PR TITLE
fix: made styling hovering buttons consistent with theme

### DIFF
--- a/media/styles/homeView.css
+++ b/media/styles/homeView.css
@@ -43,8 +43,8 @@ body {
 }
 
 .icon-link:hover, .edit-config-button:hover, .icon-button:hover {
-  background-color: var(--vscode-button-hoverBackground);
-  color: var(--vscode-editorWidget-background);
+  background-color: var(--vscode-inputOption-hoverBackground);
+  color: var(--vscode-foreground);
   text-decoration: none;
 }
 


### PR DESCRIPTION
# Changes

- changed hovering style for buttons and icons to match theme

<img width="165" alt="Screenshot 2023-09-13 at 2 20 54 PM" src="https://github.com/DevCycleHQ/vscode-extension/assets/10345366/6e6603b5-c71a-41df-869a-75f1683c645b">
<img width="176" alt="Screenshot 2023-09-13 at 2 20 47 PM" src="https://github.com/DevCycleHQ/vscode-extension/assets/10345366/1c80e11d-fec6-4c47-b569-f772d93f6f18">
