### PR TITLE
fix: Don't open browser if logging in via auto-login

### DIFF
--- a/src/cli/AuthCLIController.test.ts
+++ b/src/cli/AuthCLIController.test.ts
@@ -38,11 +38,11 @@ describe('AuthCLIController', () => {
     it('calls cli with specified org', async () => {
       mockGetState.returns(null)
 
-      const org = { name: 'org123' } as Organization
+      const org = { id: 'org_123', name: 'org123' } as Organization
       const cli = new AuthCLIController(folder)
       await cli.init(org)
 
-      sinon.assert.calledWith(execDvcStub, 'repo init --org=org123')
+      sinon.assert.calledWith(execDvcStub, 'repo init --org=org_123')
     })
   })
 
@@ -61,6 +61,22 @@ describe('AuthCLIController', () => {
       await cli.login()
 
       sinon.assert.notCalled(selectOrganizationFromConfigStub)
+      sinon.assert.notCalled(selectOrganizationFromListStub)
+    })
+
+    it('does not trigger org list selection if headlessLogin is true', async () => {
+      sinon.stub(AuthCLIController.prototype, 'isLoggedIn').resolves(false)
+      selectOrganizationFromConfigStub.resolves(false)
+      let errorThrown = false
+
+      try {
+        const cli = new AuthCLIController(folder, true)
+        await cli.login()
+      } catch (e) {
+        expect(e).to.haveOwnProperty('message', 'No organization found in config, skipping auto-login')
+        errorThrown = true
+      }
+      expect(errorThrown).to.be.true
       sinon.assert.notCalled(selectOrganizationFromListStub)
     })
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '5.6.0'
+export const CLI_VERSION = '5.9.2'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
   const settingsConfig = vscode.workspace.getConfiguration('devcycle-feature-flags')
   
   if (settingsConfig.get('loginOnWorkspaceOpen')) {
-    await utils.loginAndRefreshAll()
+    await utils.loginAndRefreshAll(true)
   }
 
   // On Hover
@@ -141,7 +141,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
   vscode.workspace.onDidChangeWorkspaceFolders(async (event) => {
     utils.checkForWorkspaceFolders()
-    await loginAndRefresh([...event.added])
+    await loginAndRefresh([...event.added], true)
   })
 
 }

--- a/src/utils/loginAndRefresh.ts
+++ b/src/utils/loginAndRefresh.ts
@@ -2,17 +2,17 @@ import * as vscode from 'vscode'
 import { AuthCLIController } from '../cli'
 import { executeRefreshAllCommand } from '../commands'
 
-export async function loginAndRefreshAll() {
+export async function loginAndRefreshAll(headlessLogin = false) {
   const { workspaceFolders = [] } = vscode.workspace
-  await loginAndRefresh([...workspaceFolders])
+  await loginAndRefresh([...workspaceFolders], headlessLogin)
 }
 
-export async function loginAndRefresh(folders: vscode.WorkspaceFolder[]) {
+export async function loginAndRefresh(folders: vscode.WorkspaceFolder[], headlessLogin = false) {
   const foldersLoggedIn = []
 
   for (const folder of folders) {
     try {
-      const cli = new AuthCLIController(folder)
+      const cli = new AuthCLIController(folder, headlessLogin)
       await cli.login()
       foldersLoggedIn.push(folder)
     } catch (e) {}


### PR DESCRIPTION
When the auto-login is triggered on workspace open or when adding folders, don't open a browser. We should only open the browser when the user had clicked the "login" button