### PR TITLE
chore: replaced ID with Type if it exists, and formatted createdAt and updatedAt

### DIFF
--- a/src/cli/VariablesCLIController.ts
+++ b/src/cli/VariablesCLIController.ts
@@ -4,6 +4,7 @@ import { BaseCLIController } from './BaseCLIController'
 
 export type Variable = {
   key: string
+  type: 'String' | 'Number' | 'Boolean' | 'JSON'
   _feature: string
   _id: string
   name: string

--- a/src/views/inspector/InspectorViewProvider.test.ts
+++ b/src/views/inspector/InspectorViewProvider.test.ts
@@ -17,6 +17,7 @@ describe('InspectorViewProvider', () => {
     var1: {
       key: 'var1',
       name: 'var1',
+      type: 'String',
       _id: 'id1',
       _feature: 'feature1',
       status: 'archived',
@@ -26,6 +27,7 @@ describe('InspectorViewProvider', () => {
     var2: {
       key: 'var2',
       name: 'var2',
+      type: 'String',
       _id: 'id2',
       _feature: 'feature2',
       status: 'active',

--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -324,19 +324,26 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
   }
 
   private getDetailsHTML(folder: vscode.WorkspaceFolder) {
-    let name, key, featureName, status, createdAt, updatedAt, description, id
+    let name, key, type, featureName, status, createdAt, updatedAt
     if (this.selectedType === 'Variable') {
       name = this.variables[this.selectedKey]?.name
       key = this.variables[this.selectedKey]?.key
+      type = this.variables[this.selectedKey]?.type
       createdAt = this.variables[this.selectedKey]?.createdAt
       updatedAt = this.variables[this.selectedKey]?.updatedAt
+
+      if (createdAt) {
+        createdAt = new Date(createdAt).toLocaleString()
+      }
+      if (updatedAt) {
+        updatedAt = new Date(updatedAt).toLocaleString()
+      }
+
       status = this.variables[this.selectedKey]?.status
-      id = this.variables[this.selectedKey]?._id
       featureName = Object.values(this.features).find((feature) => feature._id === (this.variables[this.selectedKey] as Variable)?._feature)?.name
     } else {
       name = this.features[this.selectedKey]?.name
       key = this.features[this.selectedKey]?.key
-      id = this.variables[this.selectedKey]?._id
     }
 
     const projectId = StateManager.getFolderState(folder.name, KEYS.PROJECT_ID)
@@ -363,10 +370,10 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
             <span>Key</span>
             <span class="details-value">${key}</span>
           </div>
-          <div class="detail-entry">
-            <span>ID</span>
-            <span class="details-value">${id}</span>
-          </div>
+          ${type ? `<div class="detail-entry">
+            <span>Type</span>
+            <span class="details-value">${type}</span>
+          </div>` : ''}
           ${createdAt ?
         `<div class="detail-entry">
             <span>Created Date</span>


### PR DESCRIPTION
# Changes

- replaced `ID` with `Type` for variables in inspector details
- formatted `createdAt` and `updatedAt` to look nicer

<img width="512" alt="Screenshot 2023-09-14 at 3 31 25 PM" src="https://github.com/DevCycleHQ/vscode-extension/assets/10345366/d4f2747d-2b1b-4b6d-b602-5ed99161c7d2">

