### PR TITLE
chore: show name and key for feature dropdown. Also improve loading of feature config statuses

### DIFF
--- a/src/cli/EnvironmentsCLIController.ts
+++ b/src/cli/EnvironmentsCLIController.ts
@@ -60,7 +60,7 @@ export class EnvironmentsCLIController extends BaseCLIController {
       vscode.window.showErrorMessage(
         `Retrieving environments failed: ${error?.message}}`,
       )
-      return []
+      return {}
     } else {
       const environments = JSON.parse(output) as Environment[]
       const environmentMap = environments.reduce((result, currentEnvironment) => {

--- a/src/views/inspector/index.ts
+++ b/src/views/inspector/index.ts
@@ -1,2 +1,3 @@
 export * from './InspectorViewProvider'
 export * from './registerInspectorViewProvider'
+export * from './utils'

--- a/src/views/inspector/utils.ts
+++ b/src/views/inspector/utils.ts
@@ -1,0 +1,4 @@
+import { Feature, Variable } from "../../cli";
+
+export const sortByName = (map: Record<string, Variable> | Record<string, Feature>) => 
+        Object.values(map).sort((a, b) => (a.name).localeCompare(b.name))


### PR DESCRIPTION
# Changes

- display name and key in Feature dropdown: `Name (Key)`
- fixed slow switching of feature keys by not blocking html from rendering feature configurations
- when switching to a Feature, fetch the feature configuration and reload the inspector view when it finishes


https://github.com/DevCycleHQ/vscode-extension/assets/10345366/a9111c7b-6733-49aa-b020-a563bdf6c50e

New screenshot:

<img width="529" alt="Screenshot 2023-09-19 at 1 40 03 PM" src="https://github.com/DevCycleHQ/vscode-extension/assets/10345366/36e5beab-4381-4a2c-a540-aac452cf101b">

