### PR TITLE
fix: fixed weird styling for feature link in inspector

### DIFF
--- a/media/styles/inspector.css
+++ b/media/styles/inspector.css
@@ -80,7 +80,6 @@ input[type='checkbox'] {
 
 .detail-entry-value-link {
   display: flex;
-  align-items: center;
   gap: 5px;
 }
 
@@ -100,6 +99,10 @@ input[type='checkbox'] {
   text-overflow: ellipsis;
   text-align: right;
   cursor: default;
+}
+
+.details-value-with-link {
+  width: 100%;
 }
 
 .clickable-object {


### PR DESCRIPTION
# Changes

- added extra css class for details value with link to ignore 50% width styling [here](https://github.com/DevCycleHQ/vscode-extension/pull/187/files#diff-084d91d4aa6b58d3c343d60f3c8aaaeed7b124c3d1e134d6aececb7a9a7e1f5aR524)
- rest of the changes are prettier changes
<img width="360" alt="Screenshot 2023-09-25 at 10 39 10 AM" src="https://github.com/DevCycleHQ/vscode-extension/assets/10345366/2ac8fb50-3b97-4be9-859e-d806ee731fca">

