### PR TITLE
fix: on login if headless login throws, go to login screen

### DIFF
--- a/src/utils/loginAndRefresh.test.ts
+++ b/src/utils/loginAndRefresh.test.ts
@@ -6,17 +6,27 @@ import { loginAndRefreshAll } from './loginAndRefresh'
 import { COMMAND_REFRESH_ALL } from '../commands'
 
 describe('loginAndRefreshAll', () => {
-  const folder = { name: 'test-folder', uri: vscode.Uri.parse('file:///test-folder'), index: 0 }
-  const folder2 = { name: 'test-folder2', uri: vscode.Uri.parse('file:///test-folder2'), index: 1 }
+  const folder = {
+    name: 'test-folder',
+    uri: vscode.Uri.parse('file:///test-folder'),
+    index: 0,
+  }
+  const folder2 = {
+    name: 'test-folder2',
+    uri: vscode.Uri.parse('file:///test-folder2'),
+    index: 1,
+  }
 
-  afterEach(function() {
+  afterEach(function () {
     sinon.restore()
   })
 
   it('calls login for each folder', async () => {
     sinon.stub(vscode.workspace, 'workspaceFolders').value([folder, folder2])
     sinon.stub(vscode.commands, 'executeCommand')
-    const mockLogin = sinon.stub(AuthCLIController.prototype, 'login').resolves()
+    const mockLogin = sinon
+      .stub(AuthCLIController.prototype, 'login')
+      .resolves()
 
     await loginAndRefreshAll()
 
@@ -31,7 +41,9 @@ describe('loginAndRefreshAll', () => {
     await loginAndRefreshAll()
 
     sinon.assert.calledWith(mockExecuteCommand, COMMAND_REFRESH_ALL, { folder })
-    sinon.assert.calledWith(mockExecuteCommand, COMMAND_REFRESH_ALL, { folder: folder2 })
+    sinon.assert.calledWith(mockExecuteCommand, COMMAND_REFRESH_ALL, {
+      folder: folder2,
+    })
   })
 
   it('sets hasCredentialsAndProject to true', async () => {
@@ -49,13 +61,20 @@ describe('loginAndRefreshAll', () => {
     )
   })
 
-  it('does not set hasCredentialsAndProject if an error is thrown', async () => {
+  it('sets hasCredentialsAndProject to false if an error is thrown', async () => {
     sinon.stub(vscode.workspace, 'workspaceFolders').value([folder, folder2])
     const mockExecuteCommand = sinon.stub(vscode.commands, 'executeCommand')
-    sinon.stub(AuthCLIController.prototype, 'login').throws(new Error('test error'))
+    sinon
+      .stub(AuthCLIController.prototype, 'login')
+      .throws(new Error('test error'))
 
     await loginAndRefreshAll().catch(() => {})
 
-    sinon.assert.notCalled(mockExecuteCommand)
+    sinon.assert.calledWith(
+      mockExecuteCommand,
+      'setContext',
+      'devcycle-feature-flags.hasCredentialsAndProject',
+      false,
+    )
   })
 })

--- a/src/utils/loginAndRefresh.ts
+++ b/src/utils/loginAndRefresh.ts
@@ -7,25 +7,24 @@ export async function loginAndRefreshAll(headlessLogin = false) {
   await loginAndRefresh([...workspaceFolders], headlessLogin)
 }
 
-export async function loginAndRefresh(folders: vscode.WorkspaceFolder[], headlessLogin = false) {
+export async function loginAndRefresh(
+  folders: vscode.WorkspaceFolder[],
+  headlessLogin = false,
+) {
   const foldersLoggedIn = []
 
   for (const folder of folders) {
+    const cli = new AuthCLIController(folder, headlessLogin)
     try {
-      const cli = new AuthCLIController(folder, headlessLogin)
       await cli.login()
       foldersLoggedIn.push(folder)
     } catch (e) {}
   }
-  await Promise.all(
-    foldersLoggedIn.map(executeRefreshAllCommand)
-  )
+  await Promise.all(foldersLoggedIn.map(executeRefreshAllCommand))
 
-  if (foldersLoggedIn.length > 0) {
-    await vscode.commands.executeCommand(
-      'setContext',
-      'devcycle-feature-flags.hasCredentialsAndProject',
-      true,
-    )
-  }
+  await vscode.commands.executeCommand(
+    'setContext',
+    'devcycle-feature-flags.hasCredentialsAndProject',
+    foldersLoggedIn.length > 0,
+  )
 }

--- a/src/views/login/LoginViewProvider.ts
+++ b/src/views/login/LoginViewProvider.ts
@@ -53,10 +53,7 @@ export class LoginViewProvider implements vscode.WebviewViewProvider {
     return `<p style="color:#F48771;">${errorMessage}</p>`
   }
 
-  private _getHtmlForWebview(
-    webview: vscode.Webview,
-    error?: ERRORS,
-  ) {
+  private _getHtmlForWebview(webview: vscode.Webview, error?: ERRORS) {
     const styleResetUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, 'media', 'styles', 'reset.css'),
     )


### PR DESCRIPTION
# Changes

- when using brand new project with vscode extension, it will give a blank screen since it will try to headless login with no repo config
- in this case, just go to login screen
- [this](https://github.com/DevCycleHQ/vscode-extension/pull/188/files#diff-9e8c06f26a79aa8c9d8c0d2e37fb068cdd422c6e9600f530c5c7aff92aead1b7R22) is the important change