### PR TITLE
fix: use first logged in folder for inspector view

### DIFF
--- a/src/utils/getLoggedInFolders.ts
+++ b/src/utils/getLoggedInFolders.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode'
+import { KEYS, StateManager } from '../StateManager'
+
+export const getLoggedInFolders = () => {
+  const workspaceFolders = vscode.workspace.workspaceFolders || []
+  return workspaceFolders.reduce((acc, folder) => {
+    const loggedIn =
+      StateManager.getFolderState(folder.name, KEYS.LOGGED_IN) ?? false
+    if (loggedIn) {
+      acc.push(folder)
+    }
+    return acc
+  }, [] as vscode.WorkspaceFolder[])
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,11 +3,13 @@ import * as showDebugOutput from './showDebugOutput'
 import * as loginAndRefresh from './loginAndRefresh'
 import * as logout from './logout'
 import * as checkForWorkspaceFolders from './checkForWorkspaceFolders'
+import * as getLoggedInFolders from './getLoggedInFolders'
 
 export default {
   ...loadRepoConfig,
   ...showDebugOutput,
   ...loginAndRefresh,
   ...logout,
-  ...checkForWorkspaceFolders
+  ...checkForWorkspaceFolders,
+  ...getLoggedInFolders,
 }

--- a/src/utils/loginAndRefresh.test.ts
+++ b/src/utils/loginAndRefresh.test.ts
@@ -4,6 +4,7 @@ import sinon from 'sinon'
 import { AuthCLIController } from '../cli'
 import { loginAndRefreshAll } from './loginAndRefresh'
 import { COMMAND_REFRESH_ALL } from '../commands'
+import utils from '.'
 
 describe('loginAndRefreshAll', () => {
   const folder = {
@@ -50,6 +51,7 @@ describe('loginAndRefreshAll', () => {
     sinon.stub(vscode.workspace, 'workspaceFolders').value([folder, folder2])
     const mockExecuteCommand = sinon.stub(vscode.commands, 'executeCommand')
     sinon.stub(AuthCLIController.prototype, 'login').resolves()
+    sinon.stub(utils, 'getLoggedInFolders').returns([folder, folder2])
 
     await loginAndRefreshAll()
 

--- a/src/utils/loginAndRefresh.ts
+++ b/src/utils/loginAndRefresh.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import { AuthCLIController } from '../cli'
 import { executeRefreshAllCommand } from '../commands'
+import utils from '.'
 
 export async function loginAndRefreshAll(headlessLogin = false) {
   const { workspaceFolders = [] } = vscode.workspace
@@ -11,20 +12,20 @@ export async function loginAndRefresh(
   folders: vscode.WorkspaceFolder[],
   headlessLogin = false,
 ) {
-  const foldersLoggedIn = []
+  const foldersToRefresh = []
 
   for (const folder of folders) {
     const cli = new AuthCLIController(folder, headlessLogin)
     try {
       await cli.login()
-      foldersLoggedIn.push(folder)
+      foldersToRefresh.push(folder)
     } catch (e) {}
   }
-  await Promise.all(foldersLoggedIn.map(executeRefreshAllCommand))
-
+  await Promise.all(foldersToRefresh.map(executeRefreshAllCommand))
+  const loggedInFolders = utils.getLoggedInFolders()
   await vscode.commands.executeCommand(
     'setContext',
     'devcycle-feature-flags.hasCredentialsAndProject',
-    foldersLoggedIn.length > 0,
+    loggedInFolders.length > 0,
   )
 }

--- a/src/views/inspector/utils.ts
+++ b/src/views/inspector/utils.ts
@@ -1,4 +1,5 @@
-import { Feature, Variable } from "../../cli";
+import { Feature, Variable } from '../../cli'
 
-export const sortByName = (map: Record<string, Variable> | Record<string, Feature>) => 
-        Object.values(map).sort((a, b) => (a.name).localeCompare(b.name))
+export const sortByName = (
+  map: Record<string, Variable> | Record<string, Feature>,
+) => Object.values(map).sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
# Changes

- If multiple folders in workspace and one folder is logged out, make selected folder be the first logged in folder
<img width="444" alt="Screenshot 2023-09-25 at 2 18 48 PM" src="https://github.com/DevCycleHQ/vscode-extension/assets/10345366/ad8881cb-9a27-4f0d-a28e-0637127a2186">

