### PR TITLE
chore: don't let feature text wrap in inspector

### DIFF
--- a/media/styles/inspector.css
+++ b/media/styles/inspector.css
@@ -76,6 +76,11 @@ input[type='checkbox'] {
   flex-direction: row;
   justify-content: space-between;
   padding-top: 0.4rem;
+  gap: 5px;
+}
+
+.detail-entry svg {
+  color: var(--vscode-foreground);
 }
 
 .detail-entry-value-link {
@@ -93,12 +98,15 @@ input[type='checkbox'] {
 
 .details-value {
   color: gray;
-  font-size: var(vscode-font-size - 2);
-  width: 50%;
+  font-size: var(--vscode-font-size) - 2;
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: right;
   cursor: default;
+}
+
+.detail-entry span {
+  white-space: nowrap;
 }
 
 .details-value-with-link {
@@ -129,6 +137,7 @@ span {
   color: var(--vscode-foreground);
   font-size: var(--vscode-font-size);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .detail-link-row:hover {

--- a/src/views/inspector/InspectorViewProvider.ts
+++ b/src/views/inspector/InspectorViewProvider.ts
@@ -601,7 +601,7 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
           (variable) =>
             `
       <div class="detail-entry variable-link" data-value="${variable.key}">
-        <label>${variable.key}</label>
+        <span>${variable.key}</span>
         <div>${this.inspectorSvg()}</div>
       </div>
       `,
@@ -635,8 +635,8 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
       const environment = this.environments[featureConfig._environment]
       return `
       <div class="detail-entry">
-        <label>${environment.name}</label>
-        <label class="uppercase-value">${featureConfig.status}</label>
+        <span>${environment.name}</span>
+        <span class="uppercase-value">${featureConfig.status}</span>
       </div>`
     })
 
@@ -656,12 +656,12 @@ export class InspectorViewProvider implements vscode.WebviewViewProvider {
   private inspectorSvg() {
     return `
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M6 10.052C6 7.81416 7.81416 6 10.052 6C12.2899 6 14.1041 7.81416 14.1041 10.052C14.1041 10.995 13.7818 11.8631 13.2415 12.5516L16.8571 16.1672C17.0476 16.3577 17.0476 16.6666 16.8571 16.8571C16.6666 17.0476 16.3577 17.0476 16.1672 16.8571L12.5516 13.2415C11.8631 13.7818 10.995 14.1041 10.052 14.1041C7.81416 14.1041 6 12.2899 6 10.052ZM10.052 6.97563C8.35299 6.97563 6.97563 8.35299 6.97563 10.052C6.97563 11.7511 8.35299 13.1284 10.052 13.1284C11.7511 13.1284 13.1284 11.7511 13.1284 10.052C13.1284 8.35299 11.7511 6.97563 10.052 6.97563Z" fill="var(--vscode-foreground)"/>
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M13 1.75H1V1H13V1.75Z" fill="var(--vscode-foreground)"/>
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M10 3.75H1V3H10V3.75Z" fill="var(--vscode-foreground)"/>
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M6.25 5.75H1V5H6.25V5.75Z" fill="var(--vscode-foreground)"/>
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M4 7.75H1V7H4V7.75Z" fill="var(--vscode-foreground)"/>
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M2.5 9.75H1V9H2.5V9.75Z" fill="var(--vscode-foreground)"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M6 10.052C6 7.81416 7.81416 6 10.052 6C12.2899 6 14.1041 7.81416 14.1041 10.052C14.1041 10.995 13.7818 11.8631 13.2415 12.5516L16.8571 16.1672C17.0476 16.3577 17.0476 16.6666 16.8571 16.8571C16.6666 17.0476 16.3577 17.0476 16.1672 16.8571L12.5516 13.2415C11.8631 13.7818 10.995 14.1041 10.052 14.1041C7.81416 14.1041 6 12.2899 6 10.052ZM10.052 6.97563C8.35299 6.97563 6.97563 8.35299 6.97563 10.052C6.97563 11.7511 8.35299 13.1284 10.052 13.1284C11.7511 13.1284 13.1284 11.7511 13.1284 10.052C13.1284 8.35299 11.7511 6.97563 10.052 6.97563Z" fill="currentColor"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M13 1.75H1V1H13V1.75Z" fill="currentColor"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M10 3.75H1V3H10V3.75Z" fill="currentColor"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M6.25 5.75H1V5H6.25V5.75Z" fill="currentColor"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M4 7.75H1V7H4V7.75Z" fill="currentColor"/>
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M2.5 9.75H1V9H2.5V9.75Z" fill="currentColor"/>
     </svg>
     `
   }


### PR DESCRIPTION
# Changes
* use `nowrap` on with CSS `white-space` property to stop text from wrapping in inspector view
* set inspector svg color in CSS

## Before

https://github.com/DevCycleHQ/vscode-extension/assets/33500361/c77f5211-942d-4012-bbde-f5dd886e421c

## After

https://github.com/DevCycleHQ/vscode-extension/assets/33500361/8cf44f7d-d7f6-44c8-a8fd-a332e0f8530f
