### PR TITLE
fix: hover color to match theme

### DIFF
--- a/media/styles/customDropdown.css
+++ b/media/styles/customDropdown.css
@@ -38,6 +38,7 @@
     background-color: var(--dropdown-background);
     color: var(--vscode-foreground);
     border: calc(var(--border-width) * 1px) solid var(--vscode-focusBorder);
+    box-sizing: border-box;
 }
 
 .custom-dropdown .dropdown-options div {

--- a/media/styles/customDropdown.css
+++ b/media/styles/customDropdown.css
@@ -48,6 +48,7 @@
 .custom-dropdown .dropdown-options div:hover {
     background-color: var(--list-active-selection-background);
     border: calc(var(--border-width) * 1px) solid var(--vscode-focusBorder);
+    color: var(--list-active-selection-foreground);
 }
 
 .custom-dropdown .dropdown-options.visible {


### PR DESCRIPTION
before:
![before](https://github.com/DevCycleHQ/vscode-extension/assets/69351113/16946532-282b-448d-8e50-aee12e4789c1)
now:
![now](https://github.com/DevCycleHQ/vscode-extension/assets/69351113/4bf574c1-d6c6-4ca0-85c8-9482f53fb86c)