### PR TITLE
fix: Use node version that is bundled with CLI

### DIFF
--- a/src/cli/utils/loadCli.ts
+++ b/src/cli/utils/loadCli.ts
@@ -18,7 +18,7 @@ const SUPPORTED_PLATFORMS = [
 ]
 const OUTPUT_DIR = path.join(path.resolve(__dirname), '..')
 const CLI_ROOT = path.join(OUTPUT_DIR, 'dvc')
-const CLI_EXEC = path.join(CLI_ROOT, 'bin/run')
+const CLI_EXEC = path.join(CLI_ROOT, 'bin/dvc')
 
 function getArtifactName() {
   const platform = `${process.platform}-${process.arch}`


### PR DESCRIPTION
Calling `bin/run` will use the version of node available in the user's path, calling `bin/dvc` will use the node version that is packaged with the CLI.

This ensures the extension is always using the correct node version