### PR TITLE
chore: only update usages for the saved file

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.5",
     "@types/glob": "^7.2.0",
+    "@types/lodash.partition": "^4.6.7",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
     "@types/sinon": "^10.0.15",
@@ -315,6 +316,7 @@
     "change-case": "^4.1.2",
     "fuse.js": "^6.6.2",
     "js-yaml": "^4.1.0",
+    "lodash.partition": "^4.6.0",
     "tar": "^6.1.15"
   }
 }

--- a/src/cli/UsagesCLIController.ts
+++ b/src/cli/UsagesCLIController.ts
@@ -26,25 +26,41 @@ export type Range = {
 
 export class UsagesCLIController extends BaseCLIController {
   public async usagesKeys() {
-    const usagesKeys = StateManager.getFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS)
+    const usagesKeys = StateManager.getFolderState(
+      this.folder.name,
+      KEYS.CODE_USAGE_KEYS,
+    )
     if (usagesKeys) {
       return usagesKeys
     }
     await this.usages()
-    return StateManager.getFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS) || {}
+    return (
+      StateManager.getFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS) || {}
+    )
   }
 
-  public async usages(): Promise<JSONMatch[]> {
+  public async usages(savedFilePath?: string): Promise<JSONMatch[]> {
     showBusyMessage('Finding Devcycle code usages')
-    const { output } = await this.execDvc('usages --format=json')
-    
+    const { output } = await this.execDvc(
+      `usages --format=json${
+        savedFilePath ? ` --include=${savedFilePath}` : ''
+      }`,
+    )
+
     const matches = JSON.parse(output) as JSONMatch[]
     hideBusyMessage()
-    const codeUsageKeys = matches.reduce((map, match) => {
-      map[match.key] = true
-      return map
-    }, {} as Record<string, boolean>)
-    StateManager.setFolderState(this.folder.name, KEYS.CODE_USAGE_KEYS, codeUsageKeys)
+    const codeUsageKeys = matches.reduce(
+      (map, match) => {
+        map[match.key] = true
+        return map
+      },
+      {} as Record<string, boolean>,
+    )
+    StateManager.setFolderState(
+      this.folder.name,
+      KEYS.CODE_USAGE_KEYS,
+      codeUsageKeys,
+    )
     return matches
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '5.10.3'
+export const CLI_VERSION = '5.10.5'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,7 +181,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         .getConfiguration('devcycle-feature-flags')
         .get('refreshUsagesOnSave')
     ) {
-      await usagesDataProvider.refresh(folder, false)
+      await usagesDataProvider.refresh(folder, false, filePath)
     }
   })
 

--- a/src/views/usages/UsagesTree/CodeUsageNode.ts
+++ b/src/views/usages/UsagesTree/CodeUsageNode.ts
@@ -29,11 +29,7 @@ export class CodeUsageNode extends vscode.TreeItem {
     const { key, references, variable } = match
     const folderUri = folder.uri.fsPath
     if (!variable) {
-      const notFoundNode = new CodeUsageNode(
-        key + ':not-found',
-        '',
-        'detail'
-      )
+      const notFoundNode = new CodeUsageNode(key + ':not-found', '', 'detail')
       notFoundNode.description = 'VARIABLE NOT FOUND IN DEVCYCLE'
       children.push(notFoundNode)
     } else {
@@ -51,7 +47,7 @@ export class CodeUsageNode extends vscode.TreeItem {
           'detail',
           [],
           variable.updatedAt,
-        )
+        ),
       ]
 
       if (variable.name) {
@@ -90,7 +86,9 @@ export class CodeUsageNode extends vscode.TreeItem {
       inspectorLinkNode.command = {
         title: '',
         command: OPEN_INSPECTOR_VIEW,
-        arguments: [{ buttonType: 'details', variableKey: variable.key, folderUri }],
+        arguments: [
+          { buttonType: 'details', variableKey: variable.key, folderUri },
+        ],
       }
       inspectorLinkNode.iconPath = {
         dark: vscode.Uri.joinPath(

--- a/src/views/usages/UsagesTree/UsagesTreeProvider.ts
+++ b/src/views/usages/UsagesTree/UsagesTreeProvider.ts
@@ -3,12 +3,13 @@ import {
   VariablesCLIController,
   UsagesCLIController,
   JSONMatch,
-  Variable
+  Variable,
 } from '../../../cli'
 
 import { CodeUsageNode } from './CodeUsageNode'
 import { FolderNode } from '../../utils/tree/FolderNode'
 import { KEYS, StateManager } from '../../../StateManager'
+import { updateMatchesFromSavedFile } from './utils'
 
 export class UsagesTreeProvider
   implements vscode.TreeDataProvider<CodeUsageNode>
@@ -19,23 +20,22 @@ export class UsagesTreeProvider
   readonly onDidChangeTreeData: vscode.Event<CodeUsageNode | undefined | void> =
     this._onDidChangeTreeData.event
   private flagsByFolder: Record<string, CodeUsageNode[]> = {}
+  private matchesByFolder: Record<string, JSONMatch[]> = {}
   private isRefreshing: Record<string, boolean> = {}
   sortKey: 'key' | 'createdAt' | 'updatedAt' = 'key'
   sortAsc: boolean = true
 
-  constructor(
-    private context: vscode.ExtensionContext,
-  ) {
+  constructor(private context: vscode.ExtensionContext) {
     if (!vscode.workspace.workspaceFolders) {
       throw new Error('Must have a workspace to check for code usages')
     }
   }
 
   sortData(): void {
-    Object.keys(this.flagsByFolder).forEach(folderName => {
-      this.flagsByFolder[folderName].sort(this.sortFunction);
-    });
-    this._onDidChangeTreeData.fire();
+    Object.keys(this.flagsByFolder).forEach((folderName) => {
+      this.flagsByFolder[folderName].sort(this.sortFunction)
+    })
+    this._onDidChangeTreeData.fire()
   }
 
   private sortFunction = (a: CodeUsageNode, b: CodeUsageNode): number => {
@@ -43,7 +43,9 @@ export class UsagesTreeProvider
       if (criteria === 'key') {
         return node.key
       }
-      const detailNode = node.children[0].children.find(child => child.key.includes(`:${criteria}`))
+      const detailNode = node.children[0].children.find((child) =>
+        child.key.includes(`:${criteria}`),
+      )
       return detailNode?.description || ''
     }
 
@@ -56,19 +58,21 @@ export class UsagesTreeProvider
 
   async refreshAll(): Promise<void> {
     const folders = vscode.workspace.workspaceFolders || []
-    await Promise.all(
-      folders.map((folder) => this.refresh(folder))
-    )
+    await Promise.all(folders.map((folder) => this.refresh(folder)))
   }
 
-  async refresh(folder: vscode.WorkspaceFolder, showLoading: boolean = true): Promise<void> {
+  async refresh(
+    folder: vscode.WorkspaceFolder,
+    showLoading: boolean = true,
+    savedFilePath?: string,
+  ): Promise<void> {
     const isLoggedIn = StateManager.getFolderState(folder.name, KEYS.LOGGED_IN)
     if (!isLoggedIn || this.isRefreshing[folder.name]) {
       return
     }
 
     this.isRefreshing[folder.name] = true
-    this.flagsByFolder[folder.name] = []
+    this.matchesByFolder[folder.name] = this.flagsByFolder[folder.name] = []
     if (showLoading) {
       this._onDidChangeTreeData.fire(undefined)
     }
@@ -83,22 +87,45 @@ export class UsagesTreeProvider
         const variablesCLIController = new VariablesCLIController(folder)
 
         const variables = await variablesCLIController.getAllVariables()
-        const matches = await usagesCLIController.usages()
+        const relativeSavedFilePath = savedFilePath
+          ?.replace(folder.uri.fsPath, '')
+          ?.substring(1)
+        const matches = await usagesCLIController.usages(relativeSavedFilePath)
 
-        await this.populateCodeUsagesNodes(matches, variables, folder)
-      })
+        let updatedMatches = matches
+        if (relativeSavedFilePath) {
+          updatedMatches = updateMatchesFromSavedFile(
+            this.matchesByFolder[folder.name],
+            matches,
+            relativeSavedFilePath,
+          )
+        } else {
+          // If we're not refreshing a single file, usages are called for the entire folder
+          this.matchesByFolder[folder.name] = matches
+        }
+        await this.populateCodeUsagesNodes(updatedMatches, variables, folder)
+      },
+    )
     this.isRefreshing[folder.name] = false
   }
 
-  private async populateCodeUsagesNodes(matches: JSONMatch[], variables: Record<string, Variable>, folder: vscode.WorkspaceFolder) {
+  private async populateCodeUsagesNodes(
+    matches: JSONMatch[],
+    variables: Record<string, Variable>,
+    folder: vscode.WorkspaceFolder,
+  ) {
     await Promise.all(
       matches.map(async (match) => {
         const variable = variables[match.key]
         const populatedMatch = variable ? { ...match, variable } : match
 
-        const usageNode = await CodeUsageNode.flagFrom(populatedMatch, folder, this.context)
+        const usageNode = await CodeUsageNode.flagFrom(
+          populatedMatch,
+          folder,
+          this.context,
+        )
         this.flagsByFolder[folder.name].push(usageNode)
-      })
+      }),
     )
     this.sortData()
   }
@@ -114,7 +141,7 @@ export class UsagesTreeProvider
 
     if (!element) {
       return workspaceFolders.length > 1
-        ? workspaceFolders.map((folder) => (new FolderNode(folder)))
+        ? workspaceFolders.map((folder) => new FolderNode(folder))
         : this.flagsByFolder[workspaceFolders[0].name]
     }
 
@@ -134,13 +161,16 @@ export class UsagesTreeProvider
     return element
   }
 
-  findElementByKeyInFolder(key: string, folder: vscode.WorkspaceFolder): CodeUsageNode | undefined {
+  findElementByKeyInFolder(
+    key: string,
+    folder: vscode.WorkspaceFolder,
+  ): CodeUsageNode | undefined {
     const folderNodes = this.flagsByFolder[folder.name]
     if (!folderNodes) {
       return undefined
     }
 
-    const foundNode = folderNodes.find(node => node.key === key)
+    const foundNode = folderNodes.find((node) => node.key === key)
     return foundNode
   }
 }

--- a/src/views/usages/UsagesTree/utils.test.ts
+++ b/src/views/usages/UsagesTree/utils.test.ts
@@ -1,0 +1,112 @@
+import { JSONMatch } from '../../../cli'
+import { updateMatchesFromSavedFile } from './utils'
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+describe('Usages Utils Tests', () => {
+  describe('updateMatchesFromSavedFile', () => {
+    const oldMatches: JSONMatch[] = [
+      {
+        key: 'key1',
+        references: [
+          {
+            codeSnippet: {
+              lineNumbers: { start: 110, end: 110 },
+              content: 'useVariableValue(key1, false)',
+            },
+            lineNumbers: { start: 110, end: 110 },
+            fileName: 'src/filename.ts',
+            language: 'typescript',
+          },
+          {
+            codeSnippet: {
+              lineNumbers: { start: 10, end: 10 },
+              content: 'useVariableValue(key1, false)',
+            },
+            lineNumbers: { start: 10, end: 10 },
+            fileName: 'src/otherfilename.ts',
+            language: 'typescript',
+          },
+        ],
+      },
+      {
+        key: 'key2',
+        references: [
+          {
+            codeSnippet: {
+              lineNumbers: { start: 111, end: 111 },
+              content: 'useVariableValue(key2, false)',
+            },
+            lineNumbers: { start: 111, end: 111 },
+            fileName: 'src/filename.ts',
+            language: 'typescript',
+          },
+          {
+            codeSnippet: {
+              lineNumbers: { start: 11, end: 11 },
+              content: 'useVariableValue(key2, false)',
+            },
+            lineNumbers: { start: 11, end: 11 },
+            fileName: 'src/otherfilename.ts',
+            language: 'typescript',
+          },
+        ],
+      },
+    ]
+
+    it('should remove matches for the saved file if no matches were found', () => {
+      const matches: JSONMatch[] = []
+      const savedFilePath = 'src/filename.ts'
+      const updatedMatches = updateMatchesFromSavedFile(
+        oldMatches,
+        matches,
+        savedFilePath,
+      )
+      expect(updatedMatches).to.not.equal(oldMatches)
+      expect(
+        updatedMatches.find((match) => {
+          const references = match.references
+          return references.find(
+            (reference) => reference.fileName === savedFilePath,
+          )
+        }),
+      ).to.be.undefined
+    })
+
+    it('should update matches for the saved file if matches were found', () => {
+      const matches: JSONMatch[] = [
+        {
+          key: 'key1',
+          references: [
+            {
+              codeSnippet: {
+                lineNumbers: { start: 115, end: 115 },
+                content: 'useVariableValue(key1, false)',
+              },
+              lineNumbers: { start: 115, end: 115 },
+              fileName: 'src/filename.ts',
+              language: 'typescript',
+            },
+          ],
+        },
+      ]
+      const savedFilePath = 'src/filename.ts'
+      const updatedMatches = updateMatchesFromSavedFile(
+        oldMatches,
+        matches,
+        savedFilePath,
+      )
+
+      expect(updatedMatches[0].references.length).to.equal(2)
+      expect(
+        updatedMatches[0].references.find(
+          (match) => match.fileName === savedFilePath,
+        )?.lineNumbers.start,
+      ).to.equal(115)
+      expect(updatedMatches[1].references.length).to.equal(1)
+      expect(updatedMatches[1].references[0].fileName).not.to.equal(
+        savedFilePath,
+      )
+    })
+  })
+})

--- a/src/views/usages/UsagesTree/utils.test.ts
+++ b/src/views/usages/UsagesTree/utils.test.ts
@@ -108,5 +108,37 @@ describe('Usages Utils Tests', () => {
         savedFilePath,
       )
     })
+
+    it('should add matches if new key is found', () => {
+      const fileName = 'src/filename.ts'
+      const matches: JSONMatch[] = [createMatch('key3', fileName, 115)]
+      const updatedMatches = updateMatchesFromSavedFile(
+        oldMatches,
+        matches,
+        fileName,
+      )
+
+      expect(updatedMatches.length).to.equal(3)
+      expect(updatedMatches[2].key).to.equal('key3')
+    })
+
+    const createMatch = (
+      key: string,
+      fileName: string,
+      lineNumber: number,
+    ) => ({
+      key,
+      references: [
+        {
+          codeSnippet: {
+            lineNumbers: { start: lineNumber, end: lineNumber },
+            content: `useVariableValue(${key}, false)`,
+          },
+          lineNumbers: { start: lineNumber, end: lineNumber },
+          fileName,
+          language: 'typescript',
+        },
+      ],
+    })
   })
 })

--- a/src/views/usages/UsagesTree/utils.ts
+++ b/src/views/usages/UsagesTree/utils.ts
@@ -1,0 +1,20 @@
+import { JSONMatch } from '../../../cli'
+
+export const updateMatchesFromSavedFile = (
+  oldMatches: JSONMatch[],
+  matches: JSONMatch[],
+  savedFilePath: string,
+) => {
+  return oldMatches
+    .map((match) => {
+      match.references = match.references.filter(
+        (reference) => reference.fileName !== savedFilePath,
+      )
+      const newMatch = matches.find((newMatch) => newMatch.key === match.key)
+      if (newMatch) {
+        match.references = [...match.references, ...newMatch.references]
+      }
+      return match
+    })
+    .filter((match) => match.references.length > 0)
+}

--- a/src/views/usages/UsagesTree/utils.ts
+++ b/src/views/usages/UsagesTree/utils.ts
@@ -1,20 +1,38 @@
 import { JSONMatch } from '../../../cli'
+import partition from 'lodash.partition'
 
 export const updateMatchesFromSavedFile = (
   oldMatches: JSONMatch[],
   matches: JSONMatch[],
   savedFilePath: string,
 ) => {
+  const oldMatchesMap = convertMatchesToMap(oldMatches)
+  const [existingNewMatches, newMatches] = partition(
+    matches,
+    (match) => oldMatchesMap[match.key],
+  )
+  const existingNewMatchesMap = convertMatchesToMap(existingNewMatches)
   return oldMatches
     .map((match) => {
       match.references = match.references.filter(
         (reference) => reference.fileName !== savedFilePath,
       )
-      const newMatch = matches.find((newMatch) => newMatch.key === match.key)
-      if (newMatch) {
-        match.references = [...match.references, ...newMatch.references]
+      const existingMatch = existingNewMatchesMap[match.key]
+      if (existingMatch) {
+        match.references = [...match.references, ...existingMatch.references]
       }
       return match
     })
     .filter((match) => match.references.length > 0)
+    .concat(newMatches)
+}
+
+const convertMatchesToMap = (matches: JSONMatch[]) => {
+  return matches.reduce(
+    (map, match) => {
+      map[match.key] = match
+      return map
+    },
+    {} as Record<string, JSONMatch>,
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,6 +978,18 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
+"@types/lodash.partition@^4.6.7":
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.partition/-/lodash.partition-4.6.7.tgz#7c4bcfa30e2cd945466401855eb5593a848fadff"
+  integrity sha512-tRAQtiQkNfMLPInsv+o/3vXR/YUj8YaqzFh/bdlTdVYvuydU817+dX/dM7N7sQWMQ2PgF4ziHILuvlvW4aHnnw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.199"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.199.tgz#c3edb5650149d847a277a8961a7ad360c474e9bf"
+  integrity sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==
+
 "@types/minimatch@*":
   version "5.1.2"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz"
@@ -5216,6 +5228,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.partition@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.partition/-/lodash.partition-4.6.0.tgz#a38e46b73469e0420b0da1212e66d414be364ba4"
+  integrity sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg==
 
 lodash.pickby@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
# Changes

- if calling `refresh` on `UsagesDataProvider` on save, pass in the saved file so that `dvc usages` is called with an `--include` flag to only get updated flags for the file saved
- this means we need to store matches per folder so that when we build the usages nodes we can remove/add any code usages nodes
- add tests for new utils functions