### PR TITLE
fix: reduce max chunk to one when webpacking

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 const path = require('path')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
+const webpack = require('webpack')
+
 /** @type WebpackConfig */
 const baseConfig = {
   target: 'node',
@@ -43,6 +45,11 @@ const extensionConfig = {
     libraryTarget: "commonjs2",
     devtoolModuleFilenameTemplate: '../[resource-path]'
   },
+  plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
+  ]
 };
 
 // Config for webview source code (to be run in a web-based context)


### PR DESCRIPTION
# Changes

- remove chunking when bundling with webpack to prevent multiple `extension` files from being generated