### PR TITLE
fix: fix project showing up as undefined

### DIFF
--- a/src/cli/OrganizationsCLIController.ts
+++ b/src/cli/OrganizationsCLIController.ts
@@ -29,7 +29,12 @@ export class OrganizationsCLIController extends BaseCLIController {
     }
     const { code, error, output } = await this.execDvc('organizations get')
 
-    if (code === 0) {
+    if (code !== 0) {
+      vscode.window.showErrorMessage(
+        `Retrieving organizations failed: ${error?.message}}`,
+      )
+      return {}
+    } else {
       const organizations = JSON.parse(output) as Organization[]
       const orgsMap = organizations.reduce((result, currentOrg) => {
         result[currentOrg.id] = currentOrg
@@ -38,11 +43,6 @@ export class OrganizationsCLIController extends BaseCLIController {
 
       StateManager.setWorkspaceState(KEYS.ORGANIZATIONS, orgsMap)
       return orgsMap
-    } else {
-      vscode.window.showErrorMessage(
-        `Retrieving organizations failed: ${error?.message}}`,
-      )
-      return {}
     }
   }
 

--- a/src/cli/utils/execShell.ts
+++ b/src/cli/utils/execShell.ts
@@ -16,7 +16,7 @@ export function execShell(cmd: string, cwd: string) {
         resolve({
           output: out,
           error: err,
-          code: err.code || 0,
+          code: err.code || 1, // If no error code is provided, return 1 as default code to indicate error
         })
       }
       resolve({


### PR DESCRIPTION
* Update `execShell` to return `1` when there is no error code
* `usages` method now check if the CLI returned an error before processing the usages