### PR TITLE
chore: added additional debug logging to extension activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,9 +54,12 @@ export const activate = async (context: vscode.ExtensionContext) => {
   StateManager.globalState = context.globalState
   StateManager.workspaceState = context.workspaceState
 
-  await utils.checkForWorkspaceFolders()
+  utils.showDebugOutput('DevCycle extension activating')
 
+  await utils.checkForWorkspaceFolders()
   void cliUtils.loadCli()
+
+  utils.showDebugOutput('DevCycle CLI loaded')
 
   if (!StateManager.getGlobalState(KEYS.SEND_METRICS_PROMPTED)) {
     const sendMetricsMessage = `DevCycle collects usage metrics to gather information on feature adoption, usage, and frequency. 
@@ -78,13 +81,13 @@ export const activate = async (context: vscode.ExtensionContext) => {
     await StateManager.setGlobalState(KEYS.EXTENSION_INSTALLED, true)
   }
 
+  utils.showDebugOutput('Registering View Providers')
   await registerStartupViewProvider(context)
   await registerLoginViewProvider(context)
   const { usagesDataProvider, usagesTreeView } =
     await registerUsagesViewProvider(context)
-  const environmentsDataProvider = await registerEnvironmentsViewProvider(
-    context,
-  )
+  const environmentsDataProvider =
+    await registerEnvironmentsViewProvider(context)
   const inspectorViewProvider = await registerInspectorViewProvider(context)
   const homeViewProvider = await registerHomeViewProvider(context)
   const refreshProviders: (
@@ -190,6 +193,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
     const foldersToRefresh = [...event.added, ...event.removed]
     await loginAndRefresh([...foldersToRefresh], true)
   })
+
+  utils.showDebugOutput('DevCycle extension activated')
 }
 
 export function deactivate() {}

--- a/src/utils/loginAndRefresh.ts
+++ b/src/utils/loginAndRefresh.ts
@@ -12,6 +12,7 @@ export async function loginAndRefresh(
   folders: vscode.WorkspaceFolder[],
   headlessLogin = false,
 ) {
+  utils.showDebugOutput('Logging in and refreshing all folders')
   const foldersToRefresh = []
 
   for (const folder of folders) {
@@ -21,11 +22,18 @@ export async function loginAndRefresh(
       foldersToRefresh.push(folder)
     } catch (e) {}
   }
+  utils.showDebugOutput(
+    `Logged in, refreshing all ${foldersToRefresh.length} folders`,
+  )
   await Promise.all(foldersToRefresh.map(executeRefreshAllCommand))
   const loggedInFolders = utils.getLoggedInFolders()
   await vscode.commands.executeCommand(
     'setContext',
     'devcycle-feature-flags.hasCredentialsAndProject',
     loggedInFolders.length > 0,
+  )
+
+  utils.showDebugOutput(
+    `Logged in and refreshed ${loggedInFolders.length} folders`,
   )
 }

--- a/src/views/environments/registerEnvironmentsViewProvider.ts
+++ b/src/views/environments/registerEnvironmentsViewProvider.ts
@@ -1,13 +1,17 @@
 import * as vscode from 'vscode'
 import { EnvironmentsTreeProvider } from './EnvironmentsTreeProvider'
+import utils from '../../utils'
 
-export async function registerEnvironmentsViewProvider(context: vscode.ExtensionContext) {
+export async function registerEnvironmentsViewProvider(
+  context: vscode.ExtensionContext,
+) {
   const treeDataProvider = new EnvironmentsTreeProvider()
 
-  const treeView = vscode.window.createTreeView(
-    'devcycle-environments',
-    { treeDataProvider },
-  )
+  const treeView = vscode.window.createTreeView('devcycle-environments', {
+    treeDataProvider,
+  })
+
+  utils.showDebugOutput('Registered Environments View Provider')
 
   return treeDataProvider
 }

--- a/src/views/home/registerHomeViewProvider.ts
+++ b/src/views/home/registerHomeViewProvider.ts
@@ -1,15 +1,19 @@
-
 import * as vscode from 'vscode'
 import { HomeViewProvider } from './HomeViewProvider'
+import utils from '../../utils'
 
-export async function registerHomeViewProvider(context: vscode.ExtensionContext) {
-    const homeViewProvider = new HomeViewProvider(context.extensionUri)
-    context.subscriptions.push(
-        vscode.window.registerWebviewViewProvider(
-        'devcycle-home',
-        homeViewProvider
-        ),
-    )
- 
-    return homeViewProvider
+export async function registerHomeViewProvider(
+  context: vscode.ExtensionContext,
+) {
+  const homeViewProvider = new HomeViewProvider(context.extensionUri)
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(
+      'devcycle-home',
+      homeViewProvider,
+    ),
+  )
+
+  utils.showDebugOutput('Registered Home View Provider')
+
+  return homeViewProvider
 }

--- a/src/views/inspector/registerInspectorViewProvider.ts
+++ b/src/views/inspector/registerInspectorViewProvider.ts
@@ -1,15 +1,19 @@
-
 import * as vscode from 'vscode'
 import { InspectorViewProvider } from './InspectorViewProvider'
+import utils from '../../utils'
 
-export async function registerInspectorViewProvider(context: vscode.ExtensionContext) {
-    const inspectorViewProvider = new InspectorViewProvider(context.extensionUri)
-    context.subscriptions.push(
-        vscode.window.registerWebviewViewProvider(
-            'devcycle-inspector',
-            inspectorViewProvider,
-        ),
-    )
- 
-    return inspectorViewProvider
+export async function registerInspectorViewProvider(
+  context: vscode.ExtensionContext,
+) {
+  const inspectorViewProvider = new InspectorViewProvider(context.extensionUri)
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(
+      'devcycle-inspector',
+      inspectorViewProvider,
+    ),
+  )
+
+  utils.showDebugOutput('Registered Inspector View Provider')
+
+  return inspectorViewProvider
 }

--- a/src/views/login/registerLoginViewProvider.ts
+++ b/src/views/login/registerLoginViewProvider.ts
@@ -1,14 +1,19 @@
 import * as vscode from 'vscode'
 import { LoginViewProvider } from './LoginViewProvider'
+import utils from '../../utils'
 
-export async function registerLoginViewProvider(context: vscode.ExtensionContext) {
+export async function registerLoginViewProvider(
+  context: vscode.ExtensionContext,
+) {
   const loginViewProvider = new LoginViewProvider(context.extensionUri)
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
       'devcycle-login',
-      loginViewProvider
+      loginViewProvider,
     ),
   )
+
+  utils.showDebugOutput('Registered Login View Provider')
 
   return loginViewProvider
 }

--- a/src/views/resources/registerResourcesProvider.ts
+++ b/src/views/resources/registerResourcesProvider.ts
@@ -1,14 +1,19 @@
 import * as vscode from 'vscode'
 import { ResourcesViewProvider } from './ResourcesViewProvider'
+import utils from '../../utils'
 
-export async function registerResourcesViewProvider(context: vscode.ExtensionContext) {
+export async function registerResourcesViewProvider(
+  context: vscode.ExtensionContext,
+) {
   const resourcesProvider = new ResourcesViewProvider(context.extensionUri)
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
       'devcycle-resources',
-      resourcesProvider
+      resourcesProvider,
     ),
   )
+
+  utils.showDebugOutput('Registered Resources View Provider')
 
   return resourcesProvider
 }

--- a/src/views/startup/registerStartupViewProvider.ts
+++ b/src/views/startup/registerStartupViewProvider.ts
@@ -1,15 +1,23 @@
 import * as vscode from 'vscode'
 import { STARTUP_VIEWS, StartupViewProvider } from './StartupViewProvider'
+import utils from '../../utils'
 
-export async function registerStartupViewProvider(context: vscode.ExtensionContext) {
-  const startupViewProvider = new StartupViewProvider(context.extensionUri, STARTUP_VIEWS.WORKSPACE)
+export async function registerStartupViewProvider(
+  context: vscode.ExtensionContext,
+) {
+  const startupViewProvider = new StartupViewProvider(
+    context.extensionUri,
+    STARTUP_VIEWS.WORKSPACE,
+  )
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
       'devcycle-startup',
-      startupViewProvider
+      startupViewProvider,
     ),
   )
+
+  utils.showDebugOutput('Registered Startup View Provider')
 
   return startupViewProvider
 }

--- a/src/views/usages/UsagesTree/UsagesTreeProvider.ts
+++ b/src/views/usages/UsagesTree/UsagesTreeProvider.ts
@@ -10,6 +10,7 @@ import { CodeUsageNode } from './CodeUsageNode'
 import { FolderNode } from '../../utils/tree/FolderNode'
 import { KEYS, StateManager } from '../../../StateManager'
 import { updateMatchesFromSavedFile } from './utils'
+import utils from '../../../utils'
 
 export class UsagesTreeProvider
   implements vscode.TreeDataProvider<CodeUsageNode>
@@ -66,6 +67,8 @@ export class UsagesTreeProvider
     showLoading: boolean = true,
     savedFilePath?: string,
   ): Promise<void> {
+    utils.showDebugOutput(`Refreshing usages for ${folder.name}`)
+
     const isLoggedIn = StateManager.getFolderState(folder.name, KEYS.LOGGED_IN)
     if (!isLoggedIn || this.isRefreshing[folder.name]) {
       return
@@ -113,6 +116,7 @@ export class UsagesTreeProvider
       },
     )
     this.isRefreshing[folder.name] = false
+    utils.showDebugOutput(`Finished refreshing usages for ${folder.name}`)
   }
 
   private async populateCodeUsagesNodes(
@@ -137,7 +141,7 @@ export class UsagesTreeProvider
       const noUsagesNode = new CodeUsageNode(
         'noUsages',
         'No usages found',
-        'usage'
+        'usage',
       )
       this.flagsByFolder[folder.name].push(noUsagesNode)
     }

--- a/src/views/usages/registerUsagesViewProvider.ts
+++ b/src/views/usages/registerUsagesViewProvider.ts
@@ -3,14 +3,16 @@ import { UsagesTreeProvider } from './UsagesTree'
 import { getOrganizationId } from '../../cli'
 import { trackRudderstackEvent } from '../../RudderStackService'
 import { CodeUsageNode } from './UsagesTree/CodeUsageNode'
+import utils from '../../utils'
 
-export async function registerUsagesViewProvider(context: vscode.ExtensionContext) {
+export async function registerUsagesViewProvider(
+  context: vscode.ExtensionContext,
+) {
   const usagesDataProvider = new UsagesTreeProvider(context)
 
-  const usagesTreeView = vscode.window.createTreeView(
-    'devcycle-code-usages',
-    { treeDataProvider: usagesDataProvider },
-  )
+  const usagesTreeView = vscode.window.createTreeView('devcycle-code-usages', {
+    treeDataProvider: usagesDataProvider,
+  })
   usagesTreeView.onDidChangeVisibility(async (e) => {
     const [workspaceFolder] = vscode.workspace.workspaceFolders || []
     const orgId = getOrganizationId(workspaceFolder)
@@ -22,10 +24,12 @@ export async function registerUsagesViewProvider(context: vscode.ExtensionContex
     if (node instanceof CodeUsageNode && node.type === 'usage') {
       vscode.commands.executeCommand(
         'devcycle-featureflags.usagesNodeClicked',
-        node
+        node,
       )
     }
   })
+
+  utils.showDebugOutput('Registered Usages View Provider')
 
   return { usagesDataProvider, usagesTreeView }
 }


### PR DESCRIPTION
# Changes

- added additional debug logs to extension activation flow

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
