### PR TITLE
fix: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,8 @@
     "brace-expansion@^1.1.7": "1.1.13",
     "brace-expansion@^2.0.2": "^2.0.3",
     "brace-expansion@^5.0.2": "^5.0.5",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "uuid": "14.0.0"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "undici@^6.19.5": "^6.24.0",
     "flatted": "^3.4.2",
     "lodash": "^4.18.1",
-    "brace-expansion@^1.1.7": "1.1.13",
+    "brace-expansion@^1.1.7": "^1.1.13",
     "brace-expansion@^2.0.2": "^2.0.3",
     "brace-expansion@^5.0.2": "^5.0.5",
     "picomatch": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "brace-expansion@^2.0.2": "^2.0.3",
     "brace-expansion@^5.0.2": "^5.0.5",
     "picomatch": "^2.3.2",
-    "uuid": "14.0.0"
+    "uuid": "^14.0.0"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -317,6 +317,7 @@
     "undici@^6.19.5": "^6.24.0",
     "flatted": "^3.4.2",
     "lodash": "^4.18.1",
+    "brace-expansion@^1.1.7": "1.1.13",
     "brace-expansion@^2.0.2": "^2.0.3",
     "brace-expansion@^5.0.2": "^5.0.5",
     "picomatch": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6111,12 +6111,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6111,7 +6111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:14.0.0":
+"uuid@npm:^14.0.0":
   version: 14.0.0
   resolution: "uuid@npm:14.0.0"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,13 +1659,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:1.1.13":
-  version: 1.1.13
-  resolution: "brace-expansion@npm:1.1.13"
+"brace-expansion@npm:^1.1.13":
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/384c61bb329b6adfdcc0cbbdd108dc19fb5f3e84ae15a02a74f94c6c791b5a9b035aae73b2a51929a8a478e2f0f212a771eb6a8b5b514cccfb8d0c9f2ce8cbd8
+  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,13 +1659,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+"brace-expansion@npm:1.1.13":
+  version: 1.1.13
+  resolution: "brace-expansion@npm:1.1.13"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/384c61bb329b6adfdcc0cbbdd108dc19fb5f3e84ae15a02a74f94c6c791b5a9b035aae73b2a51929a8a478e2f0f212a771eb6a8b5b514cccfb8d0c9f2ce8cbd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped \`brace-expansion\` 1.x to 1.1.13 via yarn resolution to resolve medium severity vulnerability (alert #98)
- Added \`uuid\` yarn resolution \`^14.0.0\` to resolve medium severity vulnerability (alert #99) — v14.0.0 is the first patched release (vulnerable range: < 14.0.0)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #98 | \`brace-expansion\` | **medium** | Added yarn resolution \`^1.1.13\` |
| #99 | \`uuid\` | **medium** | Added yarn resolution \`^14.0.0\` (first patched version, all < 14.0.0 are vulnerable) |