### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,327 +1,328 @@
 {
-  "name": "devcycle-feature-flags",
-  "displayName": "DevCycle Feature Flags",
-  "description": "DevCycle is an intuitive extension for Visual Studio Code, built to manage and keep track of your feature flags from the comfort of your IDE.",
-  "version": "1.4.10",
-  "publisher": "DevCycle",
-  "icon": "media/togglebot.png",
-  "engines": {
-    "vscode": "^1.64.0",
-    "node": ">=18.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/devcyclehq/vscode-extension"
-  },
-  "categories": [
-    "Other"
-  ],
-  "activationEvents": [
-    "onCommand:devcycle-feature-flags.init",
-    "onCommand:devcycle-feature-flags.status",
-    "workspaceContains:.devcycle/config.yml"
-  ],
-  "main": "./out/extension.js",
-  "contributes": {
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "dvcView",
-          "title": "DevCycle",
-          "icon": "media/togglebot-white.svg"
-        }
-      ]
+    "name": "devcycle-feature-flags",
+    "displayName": "DevCycle Feature Flags",
+    "description": "DevCycle is an intuitive extension for Visual Studio Code, built to manage and keep track of your feature flags from the comfort of your IDE.",
+    "version": "1.4.10",
+    "publisher": "DevCycle",
+    "icon": "media/togglebot.png",
+    "engines": {
+        "vscode": "^1.64.0",
+        "node": ">=18.0.0"
     },
-    "capabilities": {
-      "hoverProvider": "true"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/devcyclehq/vscode-extension"
     },
-    "views": {
-      "dvcView": [
-        {
-          "type": "webview",
-          "id": "devcycle-startup",
-          "name": "DevCycle",
-          "when": "!devcycle-feature-flags.hasWorkspaceFolders"
-        },
-        {
-          "type": "webview",
-          "id": "devcycle-login",
-          "name": "DevCycle",
-          "when": "devcycle-feature-flags.hasWorkspaceFolders && !devcycle-feature-flags.hasCredentialsAndProject"
-        },
-        {
-          "type": "webview",
-          "id": "devcycle-home",
-          "name": "Home",
-          "when": "devcycle-feature-flags.hasCredentialsAndProject"
-        },
-        {
-          "type": "webview",
-          "id": "devcycle-inspector",
-          "name": "Inspector",
-          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-        },
-        {
-          "type": "tree",
-          "id": "devcycle-code-usages",
-          "name": "Variable Usages",
-          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-        },
-        {
-          "type": "tree",
-          "id": "devcycle-environments",
-          "name": "Environments & Keys",
-          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-        },
-        {
-          "type": "webview",
-          "id": "devcycle-resources",
-          "name": "DevCycle Resources",
-          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-        }
-      ]
-    },
-    "submenus": [
-      {
-        "id": "sortMenu",
-        "label": "Sort By",
-        "icon": "$(keybindings-sort)"
-      }
+    "categories": [
+        "Other"
     ],
-    "menus": {
-      "view/item/context": [
-        {
-          "command": "devcycle-code-usages.sortByKey",
-          "when": "view == devcycle-code-usages"
-        },
-        {
-          "command": "devcycle-code-usages.sortByCreatedAt",
-          "when": "view == devcycle-code-usages"
-        },
-        {
-          "command": "devcycle-code-usages.sortByUpdatedAt",
-          "when": "view == devcycle-code-usages"
-        },
-        {
-          "command": "devcycle-feature-flags.copyToClipboard",
-          "group": "inline",
-          "when": "viewItem == copyToClipboard"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "devcycle-code-usages.sortMenu",
-          "when": "view == devcycle-code-usages.view",
-          "icon": "$(keybindings-sort)"
-        }
-      ],
-      "sortMenu": [
-        {
-          "command": "devcycle-code-usages.sortByKey"
-        },
-        {
-          "command": "devcycle-code-usages.sortByCreatedAt"
-        },
-        {
-          "command": "devcycle-code-usages.sortByUpdatedAt"
-        }
-      ],
-      "editor/context": [],
-      "view/title": [
-        {
-          "command": "devcycle-feature-flags.refresh-usages",
-          "when": "view == devcycle-code-usages",
-          "group": "navigation@1"
-        },
-        {
-          "submenu": "sortMenu",
-          "when": "view == devcycle-code-usages",
-          "group": "navigation@2"
-        },
-        {
-          "command": "devcycle-feature-flags.refresh-environments",
-          "when": "view == devcycle-environments",
-          "group": "navigation@1"
-        },
-        {
-          "command": "devcycle-feature-flags.openSettings",
-          "when": "view == devcycle-home",
-          "group": "navigation@3"
-        },
-        {
-          "command": "devcycle-feature-flags.refresh-inspector",
-          "when": "view == devcycle-inspector",
-          "group": "navigation@1"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "devcycle-feature-flags.init",
-        "category": "DevCycle",
-        "title": "Initialize Repo",
-        "icon": {
-          "light": "media/togglebot.svg",
-          "dark": "media/togglebot-white.svg"
-        },
-        "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
-      },
-      {
-        "command": "devcycle-feature-flags.logout",
-        "category": "DevCycle",
-        "title": "Log out of DevCycle",
-        "icon": {
-          "light": "media/togglebot.svg",
-          "dark": "media/togglebot-white.svg"
-        },
-        "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
-      },
-      {
-        "command": "devcycle-feature-flags.refresh-usages",
-        "category": "DevCycle",
-        "title": "Refresh Code Usages",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "devcycle-feature-flags.refresh-environments",
-        "category": "DevCycle",
-        "title": "Refresh Environments",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "devcycle-code-usages.sortByKey",
-        "title": "Sort by Key",
-        "category": "DevCycle Code Usages"
-      },
-      {
-        "command": "devcycle-code-usages.sortByCreatedAt",
-        "title": "Sort by Creation Date",
-        "category": "DevCycle Code Usages"
-      },
-      {
-        "command": "devcycle-code-usages.sortByUpdatedAt",
-        "title": "Sort by Updated Date",
-        "category": "DevCycle Code Usages"
-      },
-      {
-        "command": "devcycle-code-usages.sortMenu",
-        "title": "Sort By",
-        "category": "DevCycle",
-        "icon": "$(keybindings-sort)"
-      },
-      {
-        "command": "devcycle-feature-flags.openSettings",
-        "category": "DevCycle",
-        "title": "DevCycle Settings",
-        "icon": "$(gear)"
-      },
-      {
-        "command": "devcycle-feature-flags.copyToClipboard",
-        "title": "Copy to clipboard",
-        "icon": "$(copy)"
-      },
-      {
-        "command": "devcycle-feature-flags.refresh-inspector",
-        "category": "DevCycle",
-        "title": "Refresh Inspector",
-        "icon": "$(refresh)"
-      }
+    "activationEvents": [
+        "onCommand:devcycle-feature-flags.init",
+        "onCommand:devcycle-feature-flags.status",
+        "workspaceContains:.devcycle/config.yml"
     ],
-    "configuration": [
-      {
-        "title": "DevCycle",
-        "properties": {
-          "devcycle-feature-flags.loginOnWorkspaceOpen": {
-            "type": "boolean",
-            "default": true,
-            "description": "Automatically log in to DevCycle when a configured workspace is opened."
-          },
-          "devcycle-feature-flags.initRepoOnLogin": {
-            "type": "boolean",
-            "default": true,
-            "description": "Initialize repository with a DevCycle configuration file on login."
-          },
-          "devcycle-feature-flags.refreshUsagesOnSave": {
-            "type": "boolean",
-            "default": true,
-            "description": "Automatically check for code usages when a file is saved."
-          },
-          "devcycle-feature-flags.debug": {
-            "type": "boolean",
-            "default": false,
-            "description": "Displays debug output for the extension, including what CLI commands are being executed."
-          },
-          "devcycle-feature-flags.sendMetrics": {
-            "type": "boolean",
-            "default": false,
-            "description": "Allow DevCycle to send usage metrics."
-          }
-        }
-      }
-    ]
-  },
-  "scripts": {
-    "vscode:prepublish": "yarn run webpack",
-    "webpack": "webpack --mode production",
-    "build:test": "tsc -p ./",
-    "watch": "yarn run webpack --watch",
-    "pretest": "yarn create-analytics-file && yarn run build:test && yarn run lint",
-    "pretest:integration": "yarn pretest",
-    "lint": "eslint src/**/*.ts -f pretty",
-    "test": "node ./out/test/runTest.js",
-    "publish": "vsce publish --no-dependencies",
-    "package": "vsce package --no-dependencies",
-    "create-analytics-file": "test -f ./src/analytics.ts || echo 'export const RUDDERSTACK_KEY = \"\";' > ./src/analytics.ts"
-  },
-  "devDependencies": {
-    "@types/chai": "^4.3.9",
-    "@types/glob": "^8.1.0",
-    "@types/lodash.partition": "^4.6.8",
-    "@types/mocha": "^9.1.0",
-    "@types/node": "20.x",
-    "@types/sinon": "^10.0.15",
-    "@types/tar": "^6.1.7",
-    "@types/vscode": "^1.64.0",
-    "@typescript-eslint/eslint-plugin": "^8.6.0",
-    "@typescript-eslint/parser": "^8.6.0",
-    "@vscode/test-electron": "^2.3.6",
-    "@vscode/vsce": "^3.7.1",
-    "chai": "^4.3.10",
-    "copy-webpack-plugin": "^11.0.0",
-    "eslint": "^9.11.0",
-    "glob": "^12.0.0",
-    "mocha": "^9.2.1",
-    "prettier": "3.0.3",
-    "sinon": "^17.0.0",
-    "ts-loader": "^9.5.0",
-    "typescript": "^4.5.5",
-    "webpack": "^5.105.4",
-    "webpack-cli": "^5.1.4"
-  },
-  "dependencies": {
-    "@types/js-yaml": "^4.0.5",
-    "@types/vscode-webview": "^1.57.3",
-    "@vscode/codicons": "^0.0.33",
-    "@vscode/webview-ui-toolkit": "^1.2.2",
-    "change-case": "^4.1.2",
-    "eslint-formatter-pretty": "^6.0.1",
-    "fuse.js": "^6.6.2",
-    "js-yaml": "^4.1.1",
-    "lodash.partition": "^4.6.0",
-    "tar": "^7.5.11"
-  },
-  "resolutions": {
-    "cross-spawn@^7.0.*": "^7.0.5",
-    "serialize-javascript": "^7.0.5",
-    "minimatch@4.2.1": "^4.2.5",
-    "undici@^6.19.5": "^6.24.0",
-    "flatted": "^3.4.2",
-    "lodash": "^4.18.1",
-    "brace-expansion@^1.1.7": "^1.1.13",
-    "brace-expansion@^2.0.2": "^2.0.3",
-    "brace-expansion@^5.0.2": "^5.0.5",
-    "picomatch": "^2.3.2",
-    "uuid": "^14.0.0"
-  },
-  "packageManager": "yarn@4.12.0"
+    "main": "./out/extension.js",
+    "contributes": {
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "dvcView",
+                    "title": "DevCycle",
+                    "icon": "media/togglebot-white.svg"
+                }
+            ]
+        },
+        "capabilities": {
+            "hoverProvider": "true"
+        },
+        "views": {
+            "dvcView": [
+                {
+                    "type": "webview",
+                    "id": "devcycle-startup",
+                    "name": "DevCycle",
+                    "when": "!devcycle-feature-flags.hasWorkspaceFolders"
+                },
+                {
+                    "type": "webview",
+                    "id": "devcycle-login",
+                    "name": "DevCycle",
+                    "when": "devcycle-feature-flags.hasWorkspaceFolders && !devcycle-feature-flags.hasCredentialsAndProject"
+                },
+                {
+                    "type": "webview",
+                    "id": "devcycle-home",
+                    "name": "Home",
+                    "when": "devcycle-feature-flags.hasCredentialsAndProject"
+                },
+                {
+                    "type": "webview",
+                    "id": "devcycle-inspector",
+                    "name": "Inspector",
+                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+                },
+                {
+                    "type": "tree",
+                    "id": "devcycle-code-usages",
+                    "name": "Variable Usages",
+                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+                },
+                {
+                    "type": "tree",
+                    "id": "devcycle-environments",
+                    "name": "Environments & Keys",
+                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+                },
+                {
+                    "type": "webview",
+                    "id": "devcycle-resources",
+                    "name": "DevCycle Resources",
+                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+                }
+            ]
+        },
+        "submenus": [
+            {
+                "id": "sortMenu",
+                "label": "Sort By",
+                "icon": "$(keybindings-sort)"
+            }
+        ],
+        "menus": {
+            "view/item/context": [
+                {
+                    "command": "devcycle-code-usages.sortByKey",
+                    "when": "view == devcycle-code-usages"
+                },
+                {
+                    "command": "devcycle-code-usages.sortByCreatedAt",
+                    "when": "view == devcycle-code-usages"
+                },
+                {
+                    "command": "devcycle-code-usages.sortByUpdatedAt",
+                    "when": "view == devcycle-code-usages"
+                },
+                {
+                    "command": "devcycle-feature-flags.copyToClipboard",
+                    "group": "inline",
+                    "when": "viewItem == copyToClipboard"
+                }
+            ],
+            "commandPalette": [
+                {
+                    "command": "devcycle-code-usages.sortMenu",
+                    "when": "view == devcycle-code-usages.view",
+                    "icon": "$(keybindings-sort)"
+                }
+            ],
+            "sortMenu": [
+                {
+                    "command": "devcycle-code-usages.sortByKey"
+                },
+                {
+                    "command": "devcycle-code-usages.sortByCreatedAt"
+                },
+                {
+                    "command": "devcycle-code-usages.sortByUpdatedAt"
+                }
+            ],
+            "editor/context": [],
+            "view/title": [
+                {
+                    "command": "devcycle-feature-flags.refresh-usages",
+                    "when": "view == devcycle-code-usages",
+                    "group": "navigation@1"
+                },
+                {
+                    "submenu": "sortMenu",
+                    "when": "view == devcycle-code-usages",
+                    "group": "navigation@2"
+                },
+                {
+                    "command": "devcycle-feature-flags.refresh-environments",
+                    "when": "view == devcycle-environments",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "devcycle-feature-flags.openSettings",
+                    "when": "view == devcycle-home",
+                    "group": "navigation@3"
+                },
+                {
+                    "command": "devcycle-feature-flags.refresh-inspector",
+                    "when": "view == devcycle-inspector",
+                    "group": "navigation@1"
+                }
+            ]
+        },
+        "commands": [
+            {
+                "command": "devcycle-feature-flags.init",
+                "category": "DevCycle",
+                "title": "Initialize Repo",
+                "icon": {
+                    "light": "media/togglebot.svg",
+                    "dark": "media/togglebot-white.svg"
+                },
+                "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
+            },
+            {
+                "command": "devcycle-feature-flags.logout",
+                "category": "DevCycle",
+                "title": "Log out of DevCycle",
+                "icon": {
+                    "light": "media/togglebot.svg",
+                    "dark": "media/togglebot-white.svg"
+                },
+                "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
+            },
+            {
+                "command": "devcycle-feature-flags.refresh-usages",
+                "category": "DevCycle",
+                "title": "Refresh Code Usages",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "devcycle-feature-flags.refresh-environments",
+                "category": "DevCycle",
+                "title": "Refresh Environments",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "devcycle-code-usages.sortByKey",
+                "title": "Sort by Key",
+                "category": "DevCycle Code Usages"
+            },
+            {
+                "command": "devcycle-code-usages.sortByCreatedAt",
+                "title": "Sort by Creation Date",
+                "category": "DevCycle Code Usages"
+            },
+            {
+                "command": "devcycle-code-usages.sortByUpdatedAt",
+                "title": "Sort by Updated Date",
+                "category": "DevCycle Code Usages"
+            },
+            {
+                "command": "devcycle-code-usages.sortMenu",
+                "title": "Sort By",
+                "category": "DevCycle",
+                "icon": "$(keybindings-sort)"
+            },
+            {
+                "command": "devcycle-feature-flags.openSettings",
+                "category": "DevCycle",
+                "title": "DevCycle Settings",
+                "icon": "$(gear)"
+            },
+            {
+                "command": "devcycle-feature-flags.copyToClipboard",
+                "title": "Copy to clipboard",
+                "icon": "$(copy)"
+            },
+            {
+                "command": "devcycle-feature-flags.refresh-inspector",
+                "category": "DevCycle",
+                "title": "Refresh Inspector",
+                "icon": "$(refresh)"
+            }
+        ],
+        "configuration": [
+            {
+                "title": "DevCycle",
+                "properties": {
+                    "devcycle-feature-flags.loginOnWorkspaceOpen": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Automatically log in to DevCycle when a configured workspace is opened."
+                    },
+                    "devcycle-feature-flags.initRepoOnLogin": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Initialize repository with a DevCycle configuration file on login."
+                    },
+                    "devcycle-feature-flags.refreshUsagesOnSave": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Automatically check for code usages when a file is saved."
+                    },
+                    "devcycle-feature-flags.debug": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Displays debug output for the extension, including what CLI commands are being executed."
+                    },
+                    "devcycle-feature-flags.sendMetrics": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Allow DevCycle to send usage metrics."
+                    }
+                }
+            }
+        ]
+    },
+    "scripts": {
+        "vscode:prepublish": "yarn run webpack",
+        "webpack": "webpack --mode production",
+        "build:test": "tsc -p ./",
+        "watch": "yarn run webpack --watch",
+        "pretest": "yarn create-analytics-file && yarn run build:test && yarn run lint",
+        "pretest:integration": "yarn pretest",
+        "lint": "eslint src/**/*.ts -f pretty",
+        "test": "node ./out/test/runTest.js",
+        "publish": "vsce publish --no-dependencies",
+        "package": "vsce package --no-dependencies",
+        "create-analytics-file": "test -f ./src/analytics.ts || echo 'export const RUDDERSTACK_KEY = \"\";' > ./src/analytics.ts"
+    },
+    "devDependencies": {
+        "@types/chai": "^4.3.9",
+        "@types/glob": "^8.1.0",
+        "@types/lodash.partition": "^4.6.8",
+        "@types/mocha": "^9.1.0",
+        "@types/node": "20.x",
+        "@types/sinon": "^10.0.15",
+        "@types/tar": "^6.1.7",
+        "@types/vscode": "^1.64.0",
+        "@typescript-eslint/eslint-plugin": "^8.6.0",
+        "@typescript-eslint/parser": "^8.6.0",
+        "@vscode/test-electron": "^2.3.6",
+        "@vscode/vsce": "^3.7.1",
+        "chai": "^4.3.10",
+        "copy-webpack-plugin": "^11.0.0",
+        "eslint": "^9.11.0",
+        "glob": "^12.0.0",
+        "mocha": "^9.2.1",
+        "prettier": "3.0.3",
+        "sinon": "^17.0.0",
+        "ts-loader": "^9.5.0",
+        "typescript": "^4.5.5",
+        "webpack": "^5.105.4",
+        "webpack-cli": "^5.1.4"
+    },
+    "dependencies": {
+        "@types/js-yaml": "^4.0.5",
+        "@types/vscode-webview": "^1.57.3",
+        "@vscode/codicons": "^0.0.33",
+        "@vscode/webview-ui-toolkit": "^1.2.2",
+        "change-case": "^4.1.2",
+        "eslint-formatter-pretty": "^6.0.1",
+        "fuse.js": "^6.6.2",
+        "js-yaml": "^4.1.1",
+        "lodash.partition": "^4.6.0",
+        "tar": "^7.5.11"
+    },
+    "resolutions": {
+        "cross-spawn@^7.0.*": "^7.0.5",
+        "serialize-javascript": "^7.0.5",
+        "minimatch@4.2.1": "^4.2.5",
+        "undici@^6.19.5": "^6.24.0",
+        "flatted": "^3.4.2",
+        "lodash": "^4.18.1",
+        "brace-expansion@^1.1.7": "^1.1.13",
+        "brace-expansion@^2.0.2": "^2.0.3",
+        "brace-expansion@^5.0.2": "^5.0.5",
+        "picomatch": "^2.3.2",
+        "uuid": "^14.0.0",
+        "ip-address@npm:^9.0.5": "^10.1.1"
+    },
+    "packageManager": "yarn@4.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,328 +1,328 @@
 {
-    "name": "devcycle-feature-flags",
-    "displayName": "DevCycle Feature Flags",
-    "description": "DevCycle is an intuitive extension for Visual Studio Code, built to manage and keep track of your feature flags from the comfort of your IDE.",
-    "version": "1.4.10",
-    "publisher": "DevCycle",
-    "icon": "media/togglebot.png",
-    "engines": {
-        "vscode": "^1.64.0",
-        "node": ">=18.0.0"
+  "name": "devcycle-feature-flags",
+  "displayName": "DevCycle Feature Flags",
+  "description": "DevCycle is an intuitive extension for Visual Studio Code, built to manage and keep track of your feature flags from the comfort of your IDE.",
+  "version": "1.4.10",
+  "publisher": "DevCycle",
+  "icon": "media/togglebot.png",
+  "engines": {
+    "vscode": "^1.64.0",
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devcyclehq/vscode-extension"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:devcycle-feature-flags.init",
+    "onCommand:devcycle-feature-flags.status",
+    "workspaceContains:.devcycle/config.yml"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "dvcView",
+          "title": "DevCycle",
+          "icon": "media/togglebot-white.svg"
+        }
+      ]
     },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/devcyclehq/vscode-extension"
+    "capabilities": {
+      "hoverProvider": "true"
     },
-    "categories": [
-        "Other"
+    "views": {
+      "dvcView": [
+        {
+          "type": "webview",
+          "id": "devcycle-startup",
+          "name": "DevCycle",
+          "when": "!devcycle-feature-flags.hasWorkspaceFolders"
+        },
+        {
+          "type": "webview",
+          "id": "devcycle-login",
+          "name": "DevCycle",
+          "when": "devcycle-feature-flags.hasWorkspaceFolders && !devcycle-feature-flags.hasCredentialsAndProject"
+        },
+        {
+          "type": "webview",
+          "id": "devcycle-home",
+          "name": "Home",
+          "when": "devcycle-feature-flags.hasCredentialsAndProject"
+        },
+        {
+          "type": "webview",
+          "id": "devcycle-inspector",
+          "name": "Inspector",
+          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+        },
+        {
+          "type": "tree",
+          "id": "devcycle-code-usages",
+          "name": "Variable Usages",
+          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+        },
+        {
+          "type": "tree",
+          "id": "devcycle-environments",
+          "name": "Environments & Keys",
+          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+        },
+        {
+          "type": "webview",
+          "id": "devcycle-resources",
+          "name": "DevCycle Resources",
+          "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
+        }
+      ]
+    },
+    "submenus": [
+      {
+        "id": "sortMenu",
+        "label": "Sort By",
+        "icon": "$(keybindings-sort)"
+      }
     ],
-    "activationEvents": [
-        "onCommand:devcycle-feature-flags.init",
-        "onCommand:devcycle-feature-flags.status",
-        "workspaceContains:.devcycle/config.yml"
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "devcycle-code-usages.sortByKey",
+          "when": "view == devcycle-code-usages"
+        },
+        {
+          "command": "devcycle-code-usages.sortByCreatedAt",
+          "when": "view == devcycle-code-usages"
+        },
+        {
+          "command": "devcycle-code-usages.sortByUpdatedAt",
+          "when": "view == devcycle-code-usages"
+        },
+        {
+          "command": "devcycle-feature-flags.copyToClipboard",
+          "group": "inline",
+          "when": "viewItem == copyToClipboard"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "devcycle-code-usages.sortMenu",
+          "when": "view == devcycle-code-usages.view",
+          "icon": "$(keybindings-sort)"
+        }
+      ],
+      "sortMenu": [
+        {
+          "command": "devcycle-code-usages.sortByKey"
+        },
+        {
+          "command": "devcycle-code-usages.sortByCreatedAt"
+        },
+        {
+          "command": "devcycle-code-usages.sortByUpdatedAt"
+        }
+      ],
+      "editor/context": [],
+      "view/title": [
+        {
+          "command": "devcycle-feature-flags.refresh-usages",
+          "when": "view == devcycle-code-usages",
+          "group": "navigation@1"
+        },
+        {
+          "submenu": "sortMenu",
+          "when": "view == devcycle-code-usages",
+          "group": "navigation@2"
+        },
+        {
+          "command": "devcycle-feature-flags.refresh-environments",
+          "when": "view == devcycle-environments",
+          "group": "navigation@1"
+        },
+        {
+          "command": "devcycle-feature-flags.openSettings",
+          "when": "view == devcycle-home",
+          "group": "navigation@3"
+        },
+        {
+          "command": "devcycle-feature-flags.refresh-inspector",
+          "when": "view == devcycle-inspector",
+          "group": "navigation@1"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "devcycle-feature-flags.init",
+        "category": "DevCycle",
+        "title": "Initialize Repo",
+        "icon": {
+          "light": "media/togglebot.svg",
+          "dark": "media/togglebot-white.svg"
+        },
+        "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
+      },
+      {
+        "command": "devcycle-feature-flags.logout",
+        "category": "DevCycle",
+        "title": "Log out of DevCycle",
+        "icon": {
+          "light": "media/togglebot.svg",
+          "dark": "media/togglebot-white.svg"
+        },
+        "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
+      },
+      {
+        "command": "devcycle-feature-flags.refresh-usages",
+        "category": "DevCycle",
+        "title": "Refresh Code Usages",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "devcycle-feature-flags.refresh-environments",
+        "category": "DevCycle",
+        "title": "Refresh Environments",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "devcycle-code-usages.sortByKey",
+        "title": "Sort by Key",
+        "category": "DevCycle Code Usages"
+      },
+      {
+        "command": "devcycle-code-usages.sortByCreatedAt",
+        "title": "Sort by Creation Date",
+        "category": "DevCycle Code Usages"
+      },
+      {
+        "command": "devcycle-code-usages.sortByUpdatedAt",
+        "title": "Sort by Updated Date",
+        "category": "DevCycle Code Usages"
+      },
+      {
+        "command": "devcycle-code-usages.sortMenu",
+        "title": "Sort By",
+        "category": "DevCycle",
+        "icon": "$(keybindings-sort)"
+      },
+      {
+        "command": "devcycle-feature-flags.openSettings",
+        "category": "DevCycle",
+        "title": "DevCycle Settings",
+        "icon": "$(gear)"
+      },
+      {
+        "command": "devcycle-feature-flags.copyToClipboard",
+        "title": "Copy to clipboard",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "devcycle-feature-flags.refresh-inspector",
+        "category": "DevCycle",
+        "title": "Refresh Inspector",
+        "icon": "$(refresh)"
+      }
     ],
-    "main": "./out/extension.js",
-    "contributes": {
-        "viewsContainers": {
-            "activitybar": [
-                {
-                    "id": "dvcView",
-                    "title": "DevCycle",
-                    "icon": "media/togglebot-white.svg"
-                }
-            ]
-        },
-        "capabilities": {
-            "hoverProvider": "true"
-        },
-        "views": {
-            "dvcView": [
-                {
-                    "type": "webview",
-                    "id": "devcycle-startup",
-                    "name": "DevCycle",
-                    "when": "!devcycle-feature-flags.hasWorkspaceFolders"
-                },
-                {
-                    "type": "webview",
-                    "id": "devcycle-login",
-                    "name": "DevCycle",
-                    "when": "devcycle-feature-flags.hasWorkspaceFolders && !devcycle-feature-flags.hasCredentialsAndProject"
-                },
-                {
-                    "type": "webview",
-                    "id": "devcycle-home",
-                    "name": "Home",
-                    "when": "devcycle-feature-flags.hasCredentialsAndProject"
-                },
-                {
-                    "type": "webview",
-                    "id": "devcycle-inspector",
-                    "name": "Inspector",
-                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-                },
-                {
-                    "type": "tree",
-                    "id": "devcycle-code-usages",
-                    "name": "Variable Usages",
-                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-                },
-                {
-                    "type": "tree",
-                    "id": "devcycle-environments",
-                    "name": "Environments & Keys",
-                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-                },
-                {
-                    "type": "webview",
-                    "id": "devcycle-resources",
-                    "name": "DevCycle Resources",
-                    "when": "devcycle-feature-flags.hasWorkspaceFolders && devcycle-feature-flags.hasCredentialsAndProject"
-                }
-            ]
-        },
-        "submenus": [
-            {
-                "id": "sortMenu",
-                "label": "Sort By",
-                "icon": "$(keybindings-sort)"
-            }
-        ],
-        "menus": {
-            "view/item/context": [
-                {
-                    "command": "devcycle-code-usages.sortByKey",
-                    "when": "view == devcycle-code-usages"
-                },
-                {
-                    "command": "devcycle-code-usages.sortByCreatedAt",
-                    "when": "view == devcycle-code-usages"
-                },
-                {
-                    "command": "devcycle-code-usages.sortByUpdatedAt",
-                    "when": "view == devcycle-code-usages"
-                },
-                {
-                    "command": "devcycle-feature-flags.copyToClipboard",
-                    "group": "inline",
-                    "when": "viewItem == copyToClipboard"
-                }
-            ],
-            "commandPalette": [
-                {
-                    "command": "devcycle-code-usages.sortMenu",
-                    "when": "view == devcycle-code-usages.view",
-                    "icon": "$(keybindings-sort)"
-                }
-            ],
-            "sortMenu": [
-                {
-                    "command": "devcycle-code-usages.sortByKey"
-                },
-                {
-                    "command": "devcycle-code-usages.sortByCreatedAt"
-                },
-                {
-                    "command": "devcycle-code-usages.sortByUpdatedAt"
-                }
-            ],
-            "editor/context": [],
-            "view/title": [
-                {
-                    "command": "devcycle-feature-flags.refresh-usages",
-                    "when": "view == devcycle-code-usages",
-                    "group": "navigation@1"
-                },
-                {
-                    "submenu": "sortMenu",
-                    "when": "view == devcycle-code-usages",
-                    "group": "navigation@2"
-                },
-                {
-                    "command": "devcycle-feature-flags.refresh-environments",
-                    "when": "view == devcycle-environments",
-                    "group": "navigation@1"
-                },
-                {
-                    "command": "devcycle-feature-flags.openSettings",
-                    "when": "view == devcycle-home",
-                    "group": "navigation@3"
-                },
-                {
-                    "command": "devcycle-feature-flags.refresh-inspector",
-                    "when": "view == devcycle-inspector",
-                    "group": "navigation@1"
-                }
-            ]
-        },
-        "commands": [
-            {
-                "command": "devcycle-feature-flags.init",
-                "category": "DevCycle",
-                "title": "Initialize Repo",
-                "icon": {
-                    "light": "media/togglebot.svg",
-                    "dark": "media/togglebot-white.svg"
-                },
-                "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
-            },
-            {
-                "command": "devcycle-feature-flags.logout",
-                "category": "DevCycle",
-                "title": "Log out of DevCycle",
-                "icon": {
-                    "light": "media/togglebot.svg",
-                    "dark": "media/togglebot-white.svg"
-                },
-                "enablement": "devcycle-feature-flags.hasCredentialsAndProject == true"
-            },
-            {
-                "command": "devcycle-feature-flags.refresh-usages",
-                "category": "DevCycle",
-                "title": "Refresh Code Usages",
-                "icon": "$(refresh)"
-            },
-            {
-                "command": "devcycle-feature-flags.refresh-environments",
-                "category": "DevCycle",
-                "title": "Refresh Environments",
-                "icon": "$(refresh)"
-            },
-            {
-                "command": "devcycle-code-usages.sortByKey",
-                "title": "Sort by Key",
-                "category": "DevCycle Code Usages"
-            },
-            {
-                "command": "devcycle-code-usages.sortByCreatedAt",
-                "title": "Sort by Creation Date",
-                "category": "DevCycle Code Usages"
-            },
-            {
-                "command": "devcycle-code-usages.sortByUpdatedAt",
-                "title": "Sort by Updated Date",
-                "category": "DevCycle Code Usages"
-            },
-            {
-                "command": "devcycle-code-usages.sortMenu",
-                "title": "Sort By",
-                "category": "DevCycle",
-                "icon": "$(keybindings-sort)"
-            },
-            {
-                "command": "devcycle-feature-flags.openSettings",
-                "category": "DevCycle",
-                "title": "DevCycle Settings",
-                "icon": "$(gear)"
-            },
-            {
-                "command": "devcycle-feature-flags.copyToClipboard",
-                "title": "Copy to clipboard",
-                "icon": "$(copy)"
-            },
-            {
-                "command": "devcycle-feature-flags.refresh-inspector",
-                "category": "DevCycle",
-                "title": "Refresh Inspector",
-                "icon": "$(refresh)"
-            }
-        ],
-        "configuration": [
-            {
-                "title": "DevCycle",
-                "properties": {
-                    "devcycle-feature-flags.loginOnWorkspaceOpen": {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Automatically log in to DevCycle when a configured workspace is opened."
-                    },
-                    "devcycle-feature-flags.initRepoOnLogin": {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Initialize repository with a DevCycle configuration file on login."
-                    },
-                    "devcycle-feature-flags.refreshUsagesOnSave": {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Automatically check for code usages when a file is saved."
-                    },
-                    "devcycle-feature-flags.debug": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Displays debug output for the extension, including what CLI commands are being executed."
-                    },
-                    "devcycle-feature-flags.sendMetrics": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Allow DevCycle to send usage metrics."
-                    }
-                }
-            }
-        ]
-    },
-    "scripts": {
-        "vscode:prepublish": "yarn run webpack",
-        "webpack": "webpack --mode production",
-        "build:test": "tsc -p ./",
-        "watch": "yarn run webpack --watch",
-        "pretest": "yarn create-analytics-file && yarn run build:test && yarn run lint",
-        "pretest:integration": "yarn pretest",
-        "lint": "eslint src/**/*.ts -f pretty",
-        "test": "node ./out/test/runTest.js",
-        "publish": "vsce publish --no-dependencies",
-        "package": "vsce package --no-dependencies",
-        "create-analytics-file": "test -f ./src/analytics.ts || echo 'export const RUDDERSTACK_KEY = \"\";' > ./src/analytics.ts"
-    },
-    "devDependencies": {
-        "@types/chai": "^4.3.9",
-        "@types/glob": "^8.1.0",
-        "@types/lodash.partition": "^4.6.8",
-        "@types/mocha": "^9.1.0",
-        "@types/node": "20.x",
-        "@types/sinon": "^10.0.15",
-        "@types/tar": "^6.1.7",
-        "@types/vscode": "^1.64.0",
-        "@typescript-eslint/eslint-plugin": "^8.6.0",
-        "@typescript-eslint/parser": "^8.6.0",
-        "@vscode/test-electron": "^2.3.6",
-        "@vscode/vsce": "^3.7.1",
-        "chai": "^4.3.10",
-        "copy-webpack-plugin": "^11.0.0",
-        "eslint": "^9.11.0",
-        "glob": "^12.0.0",
-        "mocha": "^9.2.1",
-        "prettier": "3.0.3",
-        "sinon": "^17.0.0",
-        "ts-loader": "^9.5.0",
-        "typescript": "^4.5.5",
-        "webpack": "^5.105.4",
-        "webpack-cli": "^5.1.4"
-    },
-    "dependencies": {
-        "@types/js-yaml": "^4.0.5",
-        "@types/vscode-webview": "^1.57.3",
-        "@vscode/codicons": "^0.0.33",
-        "@vscode/webview-ui-toolkit": "^1.2.2",
-        "change-case": "^4.1.2",
-        "eslint-formatter-pretty": "^6.0.1",
-        "fuse.js": "^6.6.2",
-        "js-yaml": "^4.1.1",
-        "lodash.partition": "^4.6.0",
-        "tar": "^7.5.11"
-    },
-    "resolutions": {
-        "cross-spawn@^7.0.*": "^7.0.5",
-        "serialize-javascript": "^7.0.5",
-        "minimatch@4.2.1": "^4.2.5",
-        "undici@^6.19.5": "^6.24.0",
-        "flatted": "^3.4.2",
-        "lodash": "^4.18.1",
-        "brace-expansion@^1.1.7": "^1.1.13",
-        "brace-expansion@^2.0.2": "^2.0.3",
-        "brace-expansion@^5.0.2": "^5.0.5",
-        "picomatch": "^2.3.2",
-        "uuid": "^14.0.0",
-        "ip-address@npm:^9.0.5": "^10.1.1"
-    },
-    "packageManager": "yarn@4.12.0"
+    "configuration": [
+      {
+        "title": "DevCycle",
+        "properties": {
+          "devcycle-feature-flags.loginOnWorkspaceOpen": {
+            "type": "boolean",
+            "default": true,
+            "description": "Automatically log in to DevCycle when a configured workspace is opened."
+          },
+          "devcycle-feature-flags.initRepoOnLogin": {
+            "type": "boolean",
+            "default": true,
+            "description": "Initialize repository with a DevCycle configuration file on login."
+          },
+          "devcycle-feature-flags.refreshUsagesOnSave": {
+            "type": "boolean",
+            "default": true,
+            "description": "Automatically check for code usages when a file is saved."
+          },
+          "devcycle-feature-flags.debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Displays debug output for the extension, including what CLI commands are being executed."
+          },
+          "devcycle-feature-flags.sendMetrics": {
+            "type": "boolean",
+            "default": false,
+            "description": "Allow DevCycle to send usage metrics."
+          }
+        }
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "yarn run webpack",
+    "webpack": "webpack --mode production",
+    "build:test": "tsc -p ./",
+    "watch": "yarn run webpack --watch",
+    "pretest": "yarn create-analytics-file && yarn run build:test && yarn run lint",
+    "pretest:integration": "yarn pretest",
+    "lint": "eslint src/**/*.ts -f pretty",
+    "test": "node ./out/test/runTest.js",
+    "publish": "vsce publish --no-dependencies",
+    "package": "vsce package --no-dependencies",
+    "create-analytics-file": "test -f ./src/analytics.ts || echo 'export const RUDDERSTACK_KEY = \"\";' > ./src/analytics.ts"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.3.9",
+    "@types/glob": "^8.1.0",
+    "@types/lodash.partition": "^4.6.8",
+    "@types/mocha": "^9.1.0",
+    "@types/node": "20.x",
+    "@types/sinon": "^10.0.15",
+    "@types/tar": "^6.1.7",
+    "@types/vscode": "^1.64.0",
+    "@typescript-eslint/eslint-plugin": "^8.6.0",
+    "@typescript-eslint/parser": "^8.6.0",
+    "@vscode/test-electron": "^2.3.6",
+    "@vscode/vsce": "^3.7.1",
+    "chai": "^4.3.10",
+    "copy-webpack-plugin": "^11.0.0",
+    "eslint": "^9.11.0",
+    "glob": "^12.0.0",
+    "mocha": "^9.2.1",
+    "prettier": "3.0.3",
+    "sinon": "^17.0.0",
+    "ts-loader": "^9.5.0",
+    "typescript": "^4.5.5",
+    "webpack": "^5.105.4",
+    "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "@types/js-yaml": "^4.0.5",
+    "@types/vscode-webview": "^1.57.3",
+    "@vscode/codicons": "^0.0.33",
+    "@vscode/webview-ui-toolkit": "^1.2.2",
+    "change-case": "^4.1.2",
+    "eslint-formatter-pretty": "^6.0.1",
+    "fuse.js": "^6.6.2",
+    "js-yaml": "^4.1.1",
+    "lodash.partition": "^4.6.0",
+    "tar": "^7.5.11"
+  },
+  "resolutions": {
+    "cross-spawn@^7.0.*": "^7.0.5",
+    "serialize-javascript": "^7.0.5",
+    "minimatch@4.2.1": "^4.2.5",
+    "undici@^6.19.5": "^6.24.0",
+    "flatted": "^3.4.2",
+    "lodash": "^4.18.1",
+    "brace-expansion@^1.1.7": "^1.1.13",
+    "brace-expansion@^2.0.2": "^2.0.3",
+    "brace-expansion@^5.0.2": "^5.0.5",
+    "picomatch": "^2.3.2",
+    "uuid": "^14.0.0",
+    "ip-address": "^10.1.1"
+  },
+  "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3453,13 +3453,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: "npm:1.1.0"
-    sprintf-js: "npm:^1.1.3"
-  checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+"ip-address@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 
@@ -3678,13 +3675,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
   languageName: node
   linkType: hard
 
@@ -5541,13 +5531,6 @@ __metadata:
   version: 3.0.23
   resolution: "spdx-license-ids@npm:3.0.23"
   checksum: 10c0/8495620f6f2a237749cce922ea2d593a66f7885c301b1a0f5542183e7041182f27f616a8f13345cefdea0c9b3e0899328e0aa8cec100cf4f3fac4bb3bd975515
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `ip-address` to resolve medium XSS vulnerability in Address6 HTML-emitting methods

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #100 | `ip-address` | **medium** | Resolution `^9.0.5` → `^10.1.1` (resolves to 10.2.0) |