### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "lodash": "^4.18.1",
     "brace-expansion@^1.1.7": "^1.1.13",
     "brace-expansion@^2.0.2": "^2.0.3",
-    "brace-expansion@^5.0.2": "^5.0.5",
+    "brace-expansion@^5.0.2": "^5.0.6",
     "picomatch": "^2.3.2",
     "uuid": "^14.0.0",
     "ip-address": "^10.1.1"

--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "tar": "^7.5.11"
   },
   "resolutions": {
-    "fast-uri": ">=3.1.2",
+    "fast-uri": "^3.1.2",
     "cross-spawn@^7.0.*": "^7.0.5",
     "serialize-javascript": "^7.0.5",
     "minimatch@4.2.1": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -311,6 +311,7 @@
     "tar": "^7.5.11"
   },
   "resolutions": {
+    "fast-uri": ">=3.1.2",
     "cross-spawn@^7.0.*": "^7.0.5",
     "serialize-javascript": "^7.0.5",
     "minimatch@4.2.1": "^4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,12 +1678,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,7 +2795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:>=3.1.2":
+"fast-uri@npm:^3.1.2":
   version: 3.1.2
   resolution: "fast-uri@npm:3.1.2"
   checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,10 +2795,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "fast-uri@npm:3.0.1"
-  checksum: 10c0/3cd46d6006083b14ca61ffe9a05b8eef75ef87e9574b6f68f2e17ecf4daa7aaadeff44e3f0f7a0ef4e0f7e7c20fc07beec49ff14dc72d0b500f00386592f2d10
+"fast-uri@npm:>=3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolved 3 open Dependabot security alerts by bumping vulnerable transitive dependencies.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #103 | `brace-expansion` | **medium** | Bumped to 5.0.6 via yarn resolution (large numeric range defeats documented `max` DoS protection) |
| #102 | `fast-uri` | **high** | Bumped to 3.1.2 via yarn resolution (host confusion via percent-encoded authority delimiters) |
| #101 | `fast-uri` | **high** | Bumped to 3.1.2 via yarn resolution (path traversal via percent-encoded dot segments) |

Both `fast-uri` and `brace-expansion` are transitive dependencies. `resolutions` entries in `package.json` force the patched versions.