### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 dvc
 .yarn/cache
 .yarn/install-state.gz
+.worktrees/

--- a/package.json
+++ b/package.json
@@ -323,7 +323,8 @@
     "brace-expansion@^5.0.2": "^5.0.6",
     "picomatch": "^2.3.2",
     "uuid": "^14.0.0",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.1.1",
+    "qs": ">=6.15.2"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4967,12 +4967,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.9.1":
-  version: 6.14.1
-  resolution: "qs@npm:6.14.1"
+"qs@npm:>=6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/0e3b22dc451f48ce5940cbbc7c7d9068d895074f8c969c0801ac15c1313d1859c4d738e46dc4da2f498f41a9ffd8c201bd9fb12df67799b827db94cc373d2613
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `qs` to `>=6.15.2` via `resolutions` override to resolve a medium severity DoS vulnerability (alert #104)
- Also fixes `.gitignore` to add a `.worktrees/` entry and a trailing newline

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #104 | `qs` | **medium** | Added `resolutions` override to `>=6.15.2` (transitive dep via `typed-rest-client`) |