### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "lodash": "^4.18.1",
     "brace-expansion@^1.1.7": "^1.1.13",
     "brace-expansion@^2.0.2": "^2.0.3",
-    "brace-expansion@^5.0.2": "^5.0.6",
+    "brace-expansion@^5.0.2": "^5.0.7",
     "picomatch": "^2.3.2",
     "uuid": "^14.0.0",
     "ip-address": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,12 +1678,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.6":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `brace-expansion` resolution from 5.0.6 to 5.0.7 to resolve a high-severity DoS vulnerability (alert #116)

The package is a transitive dependency. The fix updates the yarn `resolutions` override in `package.json` to enforce `^5.0.7`, which is the first patched version for CVE covering the range `>= 3.0.0, < 5.0.7`.