### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,15 +311,15 @@
     "tar": "^7.5.16"
   },
   "resolutions": {
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.4",
     "cross-spawn@^7.0.*": "^7.0.5",
     "serialize-javascript": "^7.0.5",
     "minimatch@4.2.1": "^4.2.5",
     "undici@^6.19.5": "^6.27.0",
     "flatted": "^3.4.2",
     "lodash": "^4.18.1",
-    "brace-expansion@^1.1.7": "^1.1.13",
-    "brace-expansion@^2.0.2": "^2.0.3",
+    "brace-expansion@^1.1.7": "^1.1.16",
+    "brace-expansion@^2.0.2": "^2.1.2",
     "brace-expansion@^5.0.2": "^5.0.7",
     "picomatch": "^2.3.2",
     "uuid": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,22 +1659,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.13":
-  version: 1.1.14
-  resolution: "brace-expansion@npm:1.1.14"
+"brace-expansion@npm:^1.1.16":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "brace-expansion@npm:2.0.3"
+"brace-expansion@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
@@ -2795,10 +2795,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 4 open Dependabot security alerts by bumping vulnerable transitive dependencies via yarn resolutions

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #120 | `fast-uri` | **high** | Bumped to 3.1.4 via yarn resolution |
| #119 | `fast-uri` | **high** | Bumped to 3.1.4 via yarn resolution |
| #118 | `brace-expansion` | **high** | Bumped to 2.1.2 via yarn resolution |
| #117 | `brace-expansion` | **high** | Bumped to 1.1.16 via yarn resolution |